### PR TITLE
Training updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A custom CKAN extension for Data.Qld for sending API requests to Google Analytic
 
 3. The file capture_api_actions.json is a dictionary of api actions to capture to send to google analytics 
         a. The dictionary key is the name of the api_action from https://docs.ckan.org/en/2.8/api/index.html#action-api-reference
-        b. The dictionary value is the event_label sent to google analytics with the {0} replaced with the query parameter value eg. package_id. resource_id, query values
+        b. The dictionary value is the event_label sent to google analytics with the {0} replaced with the query parameter value eg. package_id, resource_id, query values, sql query
 
 4. Restart web server(s), e.g.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,22 @@ A custom CKAN extension for Data.Qld
 
 3. Add the extension to the relevant CKAN `.ini` file `plugins` definition:
 
-        ckan.plugins = ... data_qld
+        ckan.plugins = ... data_qld data_qld_googleanalytics
 
 4. Restart web server(s), e.g.
 
         sudo service apache restart
         sudo service nginx restart
+
+
+---------------
+Config Settings
+---------------
+
+# ckanext-data_qld_googleanalytics
+ckan.data_qld_googleanalytics.id = UA-1010101-1
+ckan.data_qld_googleanalytics.collection_url = http://www.google-analytics.com/collect
+# Dictionary of api actions to capture to send to google analytics.
+# Key is the api_action name
+# Value is the event_label sent to google analytics with the {0} replaced with the query parameter value eg. package_id. resource_id, query values
+ckan.data_qld_googleanalytics.capture_api_actions = {"package_show": "package_show | Package ID: {0}"}

--- a/README.md
+++ b/README.md
@@ -11,24 +11,26 @@ A custom CKAN extension for Data.Qld
         cd /usr/lib/ckan/default/src/ckanext-data-qld
         python setup.py develop
 
-3. Add the extension to the relevant CKAN `.ini` file `plugins` definition:
+# data_qld_google_analytics
+A custom CKAN extension for Data.Qld for sending API requests to Google Analytics
 
-        ckan.plugins = ... data_qld data_qld_googleanalytics
+## Setup
+
+1. Add the extension to the relevant CKAN `.ini` file `plugins` definition:
+
+        ckan.plugins = ... data_qld_google_analytics 
+
+2. Add the config settings to relevantCKAN `.ini` file 
+        # ckanext-data_qld_googleanalytics
+        ckan.data_qld_googleanalytics.id = UA-1010101-1 # Relevant Google analytics ID
+        ckan.data_qld_googleanalytics.collection_url = http://www.google-analytics.com/collect
+
+3. The file capture_api_actions.json is a dictionary of api actions to capture to send to google analytics 
+        a. The dictionary key is the name of the api_action from https://docs.ckan.org/en/2.8/api/index.html#action-api-reference
+        b. The dictionary value is the event_label sent to google analytics with the {0} replaced with the query parameter value eg. package_id. resource_id, query values
 
 4. Restart web server(s), e.g.
 
         sudo service apache restart
         sudo service nginx restart
 
-
----------------
-Config Settings
----------------
-
-# ckanext-data_qld_googleanalytics
-ckan.data_qld_googleanalytics.id = UA-1010101-1
-ckan.data_qld_googleanalytics.collection_url = http://www.google-analytics.com/collect
-# Dictionary of api actions to capture to send to google analytics.
-# Key is the api_action name
-# Value is the event_label sent to google analytics with the {0} replaced with the query parameter value eg. package_id. resource_id, query values
-ckan.data_qld_googleanalytics.capture_api_actions = {"package_show": "package_show | Package ID: {0}"}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A custom CKAN extension for Data.Qld for sending API requests to Google Analytic
         ckan.plugins = ... data_qld_google_analytics 
 
 2. Add the config settings to relevantCKAN `.ini` file 
+
         # ckanext-data_qld_googleanalytics
         ckan.data_qld_googleanalytics.id = UA-1010101-1 # Relevant Google analytics ID
         ckan.data_qld_googleanalytics.collection_url = http://www.google-analytics.com/collect

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A custom CKAN extension for Data.Qld.
         cd /usr/lib/ckan/default/src/ckanext-data-qld
         python setup.py develop
 
+3. Add the extension to the relevant CKAN `.ini` file `plugins` definition:
+
+        ckan.plugins = ... data_qld
+
 # data_qld_google_analytics
 A custom CKAN extension for Data.Qld for sending API requests to Google Analytics
 
@@ -20,15 +24,16 @@ A custom CKAN extension for Data.Qld for sending API requests to Google Analytic
 
         ckan.plugins = ... data_qld_google_analytics 
 
-2. Add the config settings to relevantCKAN `.ini` file 
+2. Add the config settings to relevant CKAN `.ini` file 
 
         # ckanext-data_qld_googleanalytics
         ckan.data_qld_googleanalytics.id = UA-1010101-1 # Relevant Google analytics ID
         ckan.data_qld_googleanalytics.collection_url = http://www.google-analytics.com/collect
 
 3. The file capture_api_actions.json is a dictionary of api actions to capture to send to google analytics 
-        a. The dictionary key is the name of the api_action from https://docs.ckan.org/en/2.8/api/index.html#action-api-reference
-        b. The dictionary value is the event_label sent to google analytics with the {0} replaced with the query parameter value eg. package_id, resource_id, query values, sql query
+
+a. The dictionary key is the name of the api_action from https://docs.ckan.org/en/2.8/api/index.html#action-api-reference
+b. The dictionary value is the event_label sent to google analytics with the {0} replaced with the query parameter value eg. package_id, resource_id, query values, sql query
 
 4. Restart web server(s), e.g.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ckanext-data-qld
-A custom CKAN extension for Data.Qld
+A custom CKAN extension for Data.Qld.
 
 ## Installation
 

--- a/ckanext/data_qld/ckan_dataset.json
+++ b/ckanext/data_qld/ckan_dataset.json
@@ -161,6 +161,26 @@
       "form_placeholder": "e.g. dd/mm/yyyy",
       "preset": "date",      
       "required": true
+    },
+    {
+      "field_name": "schema",
+      "label": "Schema",
+      "preset": "resource_schema"
+    },
+    {
+      "field_name": "validation_options",
+      "label": "Validation options",
+      "preset": "validation_options"
+    },
+    {
+      "field_name": "validation_status",
+      "label": "Validation status",
+      "preset": "hidden_in_form"
+    },
+    {
+      "field_name": "validation_timestamp",
+      "label": "Validation timestamp",
+      "preset": "hidden_in_form"
     }
   ]
 }

--- a/ckanext/data_qld/ckan_dataset.json
+++ b/ckanext/data_qld/ckan_dataset.json
@@ -148,19 +148,19 @@
       "required": true
     },
     {
-      "field_name": "size",
-      "label": "Size",
-      "form_placeholder": "e.g. 1024",
-      "validators": "scheming_required data_qld_filesize_converter",
-      "output_validators": "data_qld_filesize_formatter",
-      "required": true
-    },
-    {
       "field_name": "expiration_date",
       "label": "Next Review",
       "form_placeholder": "e.g. dd/mm/yyyy",
       "preset": "date",      
       "required": true
+    },
+    {
+      "field_name": "size",
+      "label": "Size",
+      "form_placeholder": "e.g. 1024",
+      "validators": "data_qld_filesize_converter",
+      "output_validators": "data_qld_filesize_formatter",
+      "required": false
     },
     {
       "field_name": "schema",

--- a/ckanext/data_qld/constants.py
+++ b/ckanext/data_qld/constants.py
@@ -6,3 +6,6 @@ UPDATE_DATAREQUEST_ORGANISATION = 'update_datarequest_organisation'
 CLOSE_DATAREQUEST = 'close_datarequest'
 OPEN_DATAREQUEST = 'open_datarequest'
 LIST_DATAREQUESTS = 'list_datarequests'
+
+RESOURCE_SHOW = 'resource_show'
+SCHEMA_MAIN_PATH = 'schema'

--- a/ckanext/data_qld/controller.py
+++ b/ckanext/data_qld/controller.py
@@ -3,6 +3,7 @@ import ckan.model as model
 import ckan.plugins as plugins
 import ckan.lib.helpers as helpers
 from ckan.common import request
+
 import logging
 import json
 

--- a/ckanext/data_qld/controller.py
+++ b/ckanext/data_qld/controller.py
@@ -4,6 +4,7 @@ import ckan.plugins as plugins
 import ckan.lib.helpers as helpers
 from ckan.common import request
 import logging
+import json
 
 import constants
 
@@ -27,7 +28,7 @@ class DataQldUI(base.BaseController):
         return {'model': model, 'session': model.Session,
                 'user': c.user, 'auth_user_obj': c.userobj}
  
-    def open(self, id):
+    def open_datarequest(self, id):
         data_dict = {'id': id}
         context = self._get_context()
 
@@ -56,3 +57,19 @@ class DataQldUI(base.BaseController):
         except tk.NotAuthorized as e:
             log.warn(e)
             tk.abort(403, tk._('You are not authorized to close the Data Request %s' % id))
+
+    def show_schema(self, dataset_id, resource_id):  
+        data_dict = {'id': resource_id}
+        context = self._get_context()
+
+        try:
+            tk.check_access(constants.RESOURCE_SHOW, context, data_dict)
+            resource = tk.get_action(constants.RESOURCE_SHOW)(context, data_dict)
+            schema_data = resource.get('schema')
+            c.schema_data = json.dumps(schema_data, indent=2, sort_keys=True)
+            return tk.render('schema/show.html')
+        except tk.ObjectNotFound as e:
+            tk.abort(404, tk._('Resource %s not found') % resource_id)
+        except tk.NotAuthorized as e:
+            log.warn(e)
+            tk.abort(403, tk._('You are not authorized to view the Data Scheme for the resource %s' % resource_id))

--- a/ckanext/data_qld/google_analytics/__init__.py
+++ b/ckanext/data_qld/google_analytics/__init__.py
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+# this is a namespace package
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/ckanext/data_qld/google_analytics/capture_api_actions.json
+++ b/ckanext/data_qld/google_analytics/capture_api_actions.json
@@ -1,0 +1,12 @@
+{
+    "datastore_search_sql": "datastore_search_sql | Query: {0}",
+    "datastore_search": "datastore_search | Query: {0}",
+    "package_show": "package_show | Package ID: {0}",
+    "package_search": "package_search | Package ID : {0}",
+    "resource_show": "resource_show | Resource ID : {0}",
+    "resource_search": "resource_search | Query: {0}",
+    "organization_show": "organization_show | Organisation ID: {0}",
+    "follow_dataset": "follow_dataset | Package ID: {0}",
+    "package_activity_list": "package_activity_list | Package ID: {0}",
+    "revision_show": "revision_show | Revision ID: {0}"
+}

--- a/ckanext/data_qld/google_analytics/controller.py
+++ b/ckanext/data_qld/google_analytics/controller.py
@@ -52,18 +52,18 @@ class GoogleAnalyticsApiController(ApiController):
             if api_action in capture_api_actions and isinstance(request_data, dict):
                 api_action_label = capture_api_actions.get(api_action)
             
-                paramater_value = request_data.get('id', '')
-                if paramater_value == '' and 'resource_id' in request_data:
-                    paramater_value = request_data['resource_id']
-                if paramater_value == '' and 'q' in request_data:
-                    paramater_value = request_data['q']
-                if paramater_value == '' and 'query' in request_data:
-                    paramater_value = request_data['query']
-                if paramater_value == '' and 'sql' in request_data:
-                    paramater_value = self._alter_sql(request_data['sql'])
+                parameter_value = request_data.get('id', '')
+                if parameter_value == '' and 'resource_id' in request_data:
+                    parameter_value = request_data['resource_id']
+                if parameter_value == '' and 'q' in request_data:
+                    parameter_value = request_data['q']
+                if parameter_value == '' and 'query' in request_data:
+                    parameter_value = request_data['query']
+                if parameter_value == '' and 'sql' in request_data:
+                    parameter_value = self._alter_sql(request_data['sql'])
               
                 event_action = "{0} - {1}".format(api_action, c.environ['PATH_INFO'].replace('/api/3/',''))
-                event_label = api_action_label.format(paramater_value)  
+                event_label = api_action_label.format(parameter_value)  
                 self._post_analytics(c.user, event_action, event_label, request_data)
         except Exception as e:
             log.debug(e)

--- a/ckanext/data_qld/google_analytics/controller.py
+++ b/ckanext/data_qld/google_analytics/controller.py
@@ -1,0 +1,72 @@
+import logging
+import ckan.plugins.toolkit as toolkit
+import hashlib
+import plugin
+from pylons import config
+
+from ckan.controllers.api import ApiController
+
+log = logging.getLogger('ckanext.googleanalytics')
+c = toolkit.c
+
+class GoogleAnalyticsApiController(ApiController):
+
+    def _alter_sql(self,sql_query):
+        '''Quick and dirty altering of sql to prevent injection'''
+        sql_query = sql_query.lower()
+        sql_query = sql_query.replace('select','CK_SEL')
+        sql_query = sql_query.replace('insert','CK_INS')
+        sql_query = sql_query.replace('update','CK_UPD')
+        sql_query = sql_query.replace('upsert','CK_UPS')
+        sql_query = sql_query.replace('declare','CK_DEC')
+        sql_query = sql_query[:450].strip()
+        return sql_query
+
+    # intercept API calls to record via google analytics
+    def _post_analytics(self, user, request_event_action, request_event_label, request_dict={}):
+        if plugin.GoogleAnalyticsPlugin.google_analytics_id:
+            data_dict = {
+                "v": 1,
+                "tid": plugin.GoogleAnalyticsPlugin.google_analytics_id,
+                "cid": hashlib.md5(user).hexdigest(),
+                # customer id should be obfuscated
+                "t": "event",
+                "dh": c.environ['HTTP_HOST'],
+                "dp": c.environ['PATH_INFO'],
+                "dr": c.environ.get('HTTP_REFERER', ''),
+                "ec": c.environ['HTTP_HOST'] + " CKAN API Request",
+                "ea": request_event_action,
+                "el": request_event_label
+            }
+            plugin.GoogleAnalyticsPlugin.analytics_queue.put(data_dict)
+
+    def action(self, api_action, ver=None):
+        try:
+            function = toolkit.get_action(api_action)
+            side_effect_free = getattr(function, 'side_effect_free', False)
+            request_data = self._get_request_data(try_url_params=side_effect_free)
+
+            capture_api_actions = plugin.GoogleAnalyticsPlugin.capture_api_actions
+            
+            # Only send api actions if it is in the capture_api_actions dictionary
+            if api_action in capture_api_actions and isinstance(request_data, dict):
+                api_action_label = capture_api_actions.get(api_action)
+            
+                paramater_value = request_data.get('id', '')
+                if paramater_value == '' and 'resource_id' in request_data:
+                    paramater_value = request_data['resource_id']
+                if paramater_value == '' and 'q' in request_data:
+                    paramater_value = request_data['q']
+                if paramater_value == '' and 'query' in request_data:
+                    paramater_value = request_data['query']
+                if paramater_value == '' and 'sql' in request_data:
+                    paramater_value = self._alter_sql(request_data['sql'])
+              
+                event_action = "{0} - {1}".format(api_action, c.environ['PATH_INFO'].replace('/api/3/',''))
+                event_label = api_action_label.format(paramater_value)  
+                self._post_analytics(c.user, event_action, event_label, request_data)
+        except Exception as e:
+            log.debug(e)
+            pass
+
+        return ApiController.action(self, api_action, ver)

--- a/ckanext/data_qld/google_analytics/plugin.py
+++ b/ckanext/data_qld/google_analytics/plugin.py
@@ -1,0 +1,85 @@
+import logging
+import urllib
+import requests
+import ckan.plugins as p
+from routes.mapper import SubMapper
+from pylons import config
+import json
+import threading
+import Queue
+from os import path
+
+log = logging.getLogger('ckanext.googleanalytics')
+
+
+class AnalyticsPostThread(threading.Thread):
+    """Threaded Url POST"""
+    def __init__(self, queue):
+        threading.Thread.__init__(self)
+        self.queue = queue
+        self.ga_collection_url = config.get('ckan.data_qld_googleanalytics.collection_url', 'https://www.google-analytics.com/collect')
+
+    def run(self):
+        #User-Agent must be present, GA might ignore a custom UA
+        headers = {
+            'Content-Type':'application/x-www-form-urlencoded',
+            'User-Agent':'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1'
+        }
+        while True:
+            # grabs host from queue
+            data_dict = self.queue.get()
+            log.debug("Sending API event to Google Analytics: " + data_dict['ea'])
+            # send analytics
+            try:
+                data = urllib.urlencode(data_dict)
+                response = requests.post(self.ga_collection_url, data=data,headers=headers,timeout=5)
+                # signals to queue job is done
+                self.queue.task_done()
+            except:
+                #If error posting dont try again or attempt to fix just discard from queue
+                self.queue.task_done()
+
+
+class GoogleAnalyticsPlugin(p.SingletonPlugin):
+    p.implements(p.IConfigurable, inherit=True)
+    p.implements(p.IRoutes, inherit=True)
+
+    analytics_queue = Queue.Queue()
+    capture_api_actions = {}
+    google_analytics_id = None
+
+    def configure(self, config):
+        '''Load config settings for this extension from config file.
+
+        See IConfigurable.
+
+        '''
+        # Load capture_api_actions from JSON file
+        here = path.abspath(path.dirname(__file__))
+        with open(path.join(here, 'capture_api_actions.json')) as json_file:  
+            GoogleAnalyticsPlugin.capture_api_actions = json.load(json_file)
+
+        # Get google_analytics_id from config file
+        GoogleAnalyticsPlugin.google_analytics_id = config.get('ckan.data_qld_googleanalytics.id')
+      
+        # spawn a pool of 5 threads, and pass them queue instance
+        for i in range(5):
+            t = AnalyticsPostThread(self.analytics_queue)
+            t.setDaemon(True)
+            t.start()
+
+    def before_map(self, map):
+        '''Add new routes that this extension's controllers handle.
+
+        See IRoutes.
+
+        '''
+        # Helpers to reduce code clutter
+        GET_POST = dict(method=['GET', 'POST'])
+        # /api ver 3 or none
+        with SubMapper(map, controller='ckanext.data_qld.google_analytics.controller:GoogleAnalyticsApiController', path_prefix='/api{ver:/3|}', ver='/3') as m:
+            m.connect('/action/{api_action}', action='action', conditions=GET_POST)
+
+        return map
+
+

--- a/ckanext/data_qld/helpers.py
+++ b/ckanext/data_qld/helpers.py
@@ -106,6 +106,7 @@ def datarequest_suggested_description():
     '''
     return config.get('ckanext.data_qld.datarequest_suggested_description', '')
 
+
 def format_activity_data(data):
     '''Returns the activity data with actors username replaced with Publisher for non-editor/admin/sysadmin users
 
@@ -123,3 +124,10 @@ def format_activity_data(data):
         actor['style'] = 'margin-left:-40px' 
 
     return str(soup)
+
+
+# Data.Qld specific comments helper functions
+
+def get_datarequest_comments_badge(datarequest_id):
+    return toolkit.render_snippet('datarequests/snippets/badge.html',
+                             {'comments_count': toolkit.h.get_comment_count_for_dataset(datarequest_id, 'datarequest')})

--- a/ckanext/data_qld/plugin.py
+++ b/ckanext/data_qld/plugin.py
@@ -8,6 +8,7 @@ import auth_functions as auth
 import constants
 import helpers
 import converters
+import cgi
 
 
 class DataQldPlugin(plugins.SingletonPlugin):
@@ -18,6 +19,7 @@ class DataQldPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IRoutes, inherit=True)
+    plugins.implements(plugins.IResourceController, inherit=True)
 
     # IConfigurer
     def update_config(self, config_):
@@ -96,3 +98,22 @@ class DataQldPlugin(plugins.SingletonPlugin):
                   action='show_schema', conditions=dict(method=['GET']))
 
         return m
+
+
+    # IResourceController
+    def before_create(self, context, data_dict):
+        return self.check_file_upload(data_dict)
+       
+    def before_update(self, context, current_resource, updated_resource):
+        return self.check_file_upload(updated_resource)
+
+    def check_file_upload(self, data_dict):
+        # This method it to fix a bug that the ckanext-scheming creates for setting the filesize of an uploaded resource
+        # Currently the actions resource_create and resource_update will only set the resource size if the key does not exist in the data_dict
+        # So we will check if the resource is a file upload and remove the 'size' dictionary item from the data_dict 
+        # The action resource_create and resource_update will then set the data_dict['size'] = upload.filesize if 'size' not in data_dict
+        file_upload = data_dict.get(u'upload', None)
+        if isinstance(file_upload, cgi.FieldStorage):
+            data_dict.pop(u'size', None) 
+
+        return data_dict

--- a/ckanext/data_qld/plugin.py
+++ b/ckanext/data_qld/plugin.py
@@ -43,7 +43,8 @@ class DataQldPlugin(plugins.SingletonPlugin):
                 'data_qld_organisation_list': helpers.organisation_list,
                 'data_qld_datarequest_suggested_description': helpers.datarequest_suggested_description,
                 'data_qld_user_has_admin_access': helpers.user_has_admin_access,
-                'data_qld_format_activity_data': helpers.format_activity_data
+                'data_qld_format_activity_data': helpers.format_activity_data,
+                'get_datarequest_comments_badge': helpers.get_datarequest_comments_badge,
                 }
 
     # IValidators

--- a/ckanext/data_qld/plugin.py
+++ b/ckanext/data_qld/plugin.py
@@ -89,6 +89,10 @@ class DataQldPlugin(plugins.SingletonPlugin):
         # Re_Open a Data Request
         m.connect('/%s/open/{id}' % constants.DATAREQUESTS_MAIN_PATH,
                   controller='ckanext.data_qld.controller:DataQldUI',
-                  action='open', conditions=dict(method=['GET', 'POST']))
+                  action='open_datarequest', conditions=dict(method=['GET', 'POST']))
+        
+        m.connect('/dataset/{dataset_id}/resource/{resource_id}/%s/show/' % constants.SCHEMA_MAIN_PATH,
+                  controller='ckanext.data_qld.controller:DataQldUI',
+                  action='show_schema', conditions=dict(method=['GET']))
 
         return m

--- a/ckanext/data_qld/presets.json
+++ b/ckanext/data_qld/presets.json
@@ -1,0 +1,31 @@
+{
+  "scheming_presets_version": 1,
+  "about": "Presets related to data validation",
+  "about_url": "",
+  "presets": [
+    {
+      "preset_name": "resource_schema",
+      "values": {
+        "validators": "ignore_missing resource_schema_validator",
+        "output_validators": "scheming_load_json",
+        "form_snippet": "resource_schema.html",
+        "display_snippet": "schema_link.html"
+      }
+    },
+    {
+      "preset_name": "validation_options",
+      "values": {
+        "validators": "ignore_missing scheming_valid_json_object validation_options_validator",
+        "output_validators": "scheming_load_json",
+        "form_snippet": "validation_options.html",
+        "display_snippet": "json.html"
+      }
+    },
+    {
+      "preset_name": "hidden_in_form",
+      "values": {
+        "form_snippet": "hidden.html"
+      }
+    }
+  ]
+}

--- a/ckanext/data_qld/templates/admin/config.html
+++ b/ckanext/data_qld/templates/admin/config.html
@@ -4,7 +4,20 @@
 
 {% block admin_form %}
 
-  {{ super() }}
+  {{ form.input('ckan.site_title', id='field-ckan-site-title', label=_('Site Title'), value=data['ckan.site_title'], error=error, classes=['control-medium']) }}
+
+  {{ form.input('ckan.site_description', id='field-ckan-site-description', label=_('Site Tag Line'), value=data['ckan.site_description'], error=error, classes=['control-medium']) }}
+
+  {% set field_url = 'ckan.site_logo' %}
+  {% set is_upload = data[field_url] and not data[field_url].startswith('http') %}
+  {% set is_url = data[field_url] and data[field_url].startswith('http') %}
+  {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label = _('Site logo'), url_label=_('Site logo'),  field_url=field_url, field_upload='logo_upload', field_clear='clear_logo_upload' )}}
+
+  {{ form.markdown('ckan.site_about', id='field-ckan-site-about', label=_('About'), value=data['ckan.site_about'], error=error, placeholder=_('About page text')) }}
+
+  {{ form.markdown('ckan.site_intro_text', id='field-ckan-site-intro-text', label=_('Intro Text'), value=data['ckan.site_intro_text'], error=error, placeholder=_('Text on home page')) }}
+
+  {{ form.select('ckan.homepage_style', id='field-homepage-style', label=_('Homepage'), options=homepages, selected=data['ckan.homepage_style'], error=error) }}
 
   <h3>Data Request Config</h3>
 
@@ -15,8 +28,21 @@
 
 {% block admin_form_help %}
 
-  {{ super() }}
-
-  <p><strong>Data Request Suggested Description :</strong> guidance on what information to include</p>
+  {% set about_url = h.url_for(controller='home', action='about') %}
+  {% set home_url = h.url_for(controller='home', action='index') %}
+  {% set docs_url = "http://docs.ckan.org/en/{0}/theming".format(g.ckan_doc_version) %}
+  {% trans %}
+    <p><strong>Site Title:</strong> This is the title of this CKAN instance
+      It appears in various places throughout CKAN.</p>
+    <p><strong>Site Tag Logo:</strong> This is the logo that appears in the
+      header of all the CKAN instance templates.</p>
+    <p><strong>About:</strong> This text will appear on this CKAN instances
+      <a href="{{ about_url }}">about page</a>.</p>
+    <p><strong>Intro Text:</strong> This text will appear on this CKAN instances
+      <a href="{{ home_url }}">home page</a> as a welcome to visitors.</p>
+    <p><strong>Homepage:</strong> This is for choosing a predefined layout for
+      the modules that appear on your homepage.</p>
+    <p><strong>Data Request Suggested Description:</strong> Guidance on what information to include</p>
+  {% endtrans %}
 
 {% endblock %}

--- a/ckanext/data_qld/templates/emails/subjects/close_datarequest_creator.txt
+++ b/ckanext/data_qld/templates/emails/subjects/close_datarequest_creator.txt
@@ -1,1 +1,1 @@
-[{{ site_title }}] - Data Request
+Queensland Government Open Data - Data Request

--- a/ckanext/data_qld/templates/emails/subjects/new_datarequest_organisation.txt
+++ b/ckanext/data_qld/templates/emails/subjects/new_datarequest_organisation.txt
@@ -1,1 +1,1 @@
-[{{ site_title }}] - Data Request
+Queensland Government Open Data - Data Request

--- a/ckanext/data_qld/templates/emails/subjects/open_datarequest_creator.txt
+++ b/ckanext/data_qld/templates/emails/subjects/open_datarequest_creator.txt
@@ -1,1 +1,1 @@
-[{{ site_title }}] - Data Request
+Queensland Government Open Data - Data Request

--- a/ckanext/data_qld/templates/emails/subjects/open_datarequest_organisation.txt
+++ b/ckanext/data_qld/templates/emails/subjects/open_datarequest_organisation.txt
@@ -1,1 +1,1 @@
-[{{ site_title }}] - Data Request
+Queensland Government Open Data - Data Request

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
     entry_points='''
         [ckan.plugins]
         data_qld=ckanext.data_qld.plugin:DataQldPlugin
+        data_qld_google_analytics=ckanext.data_qld.google_analytics.plugin:GoogleAnalyticsPlugin
 
         [paste.paster_command]
         migrate_extras = ckanext.data_qld.commands:MigrateExtras


### PR DESCRIPTION
This PR contains updates for the following Jira stories:

- DQL-32 - Google Analytics - API call event tracking
- DQL-55 - Bug: CKAN Sysadmin unable to update Config
- DQL-27 - Data Base & Form updates
- DQL-39 - Data Requests - Ability to Re-open Data Request
- DQL-19 - Modify CKAN dataset schema

Please note: Some updates for these stories will already exist in the `develop` branch as at the point it was branched to `training`.