### PR TITLE
[DQL-188] EPIC - Dataset comment enhancements

### DIFF
--- a/ckanext/data_qld/helpers.py
+++ b/ckanext/data_qld/helpers.py
@@ -135,12 +135,6 @@ def format_activity_data(data):
 
 # Data.Qld specific comments helper functions
 
-def get_datarequest_comments_badge(datarequest_id):
-    return toolkit.render_snippet('datarequests/snippets/badge.html',
-                                  {'comments_count': toolkit.h.get_comment_count_for_dataset(datarequest_id,
-                                                                                             'datarequest')})
-
-
 def resource_formats(field):
     """Returns a list of resource formats from admin config
 

--- a/ckanext/data_qld/integration_plugin.py
+++ b/ckanext/data_qld/integration_plugin.py
@@ -43,8 +43,7 @@ class DataQldIntegrationPlugin(plugins.SingletonPlugin):
     # ITemplateHelpers
     def get_helpers(self):
         return {'data_qld_datarequest_default_organisation_id': helpers.datarequest_default_organisation_id,
-                'data_qld_datarequest_suggested_description': helpers.datarequest_suggested_description,
-                'get_datarequest_comments_badge': helpers.get_datarequest_comments_badge
+                'data_qld_datarequest_suggested_description': helpers.datarequest_suggested_description
                 }
 
     # IValidators

--- a/ckanext/data_qld/plugin.py
+++ b/ckanext/data_qld/plugin.py
@@ -52,7 +52,6 @@ class DataQldPlugin(plugins.SingletonPlugin):
                 'data_qld_datarequest_suggested_description': helpers.datarequest_suggested_description,
                 'data_qld_user_has_admin_access': helpers.user_has_admin_access,
                 'data_qld_format_activity_data': helpers.format_activity_data,
-                'get_datarequest_comments_badge': helpers.get_datarequest_comments_badge,
                 'data_qld_resource_formats': helpers.resource_formats
                 }
 


### PR DESCRIPTION
- [DQL2-24] Refactored get_datarequest_comments_badge to get_content_type_comments_badge so it can be used for different content_types
- [DQL2-24] Removed comment badge helpers and moved them into ytp-comments