### PR TITLE
[DQL2-21] Fix search pagination

### DIFF
--- a/ckanext/data_qld/controller.py
+++ b/ckanext/data_qld/controller.py
@@ -84,8 +84,8 @@ class DataQldUI(base.BaseController):
 class DataQldDataset(PackageController):
     def _get_context(self):
         return {'model': model, 'session': model.Session,
-                       'user': c.user, 'for_view': True,
-                       'auth_user_obj': c.userobj}
+                'user': c.user, 'for_view': True,
+                'auth_user_obj': c.userobj}
 
     def _is_dataset_private(self, id):
         try:

--- a/ckanext/data_qld/plugin.py
+++ b/ckanext/data_qld/plugin.py
@@ -116,7 +116,7 @@ class DataQldPlugin(plugins.SingletonPlugin):
         # so we need to replicate them here
         m.connect('dataset_new', '/dataset/new', controller='package', action='new')
         m.connect('/dataset/{action}',
-                  controller='package',
+                  controller='ckan.controllers.package',
                   requirements=dict(action='|'.join([
                       'list',
                       'autocomplete',

--- a/test/features/login_redirect.feature
+++ b/test/features/login_redirect.feature
@@ -45,11 +45,3 @@ Feature: Login Redirection
         When I log in directly
         Then I should see an element with xpath "//h1[contains(string(), 'A Novel By Tolstoy')]"
         And I should see an element with xpath "//span[contains(string(), 'Private')]"
-
-    @private_dataset_resource
-    Scenario: As an unauthenticated organisation member, when I visit the URL of a private dataset resource I see the login page. Upon logging in I am taken to the private dataset resource
-        Given "TestOrgMember" as the persona
-        When I visit "/dataset/annakarenina/resource/e5966553-46d7-404c-a08d-67d7331a099e"
-        Then I should see an element with xpath "//h1[contains(string(), 'Login')]"
-        When I log in directly
-        Then I should see an element with xpath "//h1[contains(string(), 'Full text')]"


### PR DESCRIPTION
This PR fixes an issue with the pagination on the dataset listing pages / search by adjusting the `/dataset/{action}` route controller.

@duttonw & @ThrawnCA - for review please.