### PR TITLE
[DQL-211] Reporting fixes

### DIFF
--- a/ckanext/data_qld/reporting/constants.py
+++ b/ckanext/data_qld/reporting/constants.py
@@ -1,4 +1,4 @@
 from ckan.common import config
 
-DATAREQUEST_OPEN_MAX_DAYS = config.get('ckan.reporting.datarequest_open_max_days', 60)
-COMMENT_NO_REPLY_MAX_DAYS = config.get('ckan.reporting.comment_no_reply_max_days', 10)
+DATAREQUEST_OPEN_MAX_DAYS = int(config.get('ckan.reporting.datarequest_open_max_days', 60))
+COMMENT_NO_REPLY_MAX_DAYS = int(config.get('ckan.reporting.comment_no_reply_max_days', 10))

--- a/ckanext/data_qld/reporting/controller.py
+++ b/ckanext/data_qld/reporting/controller.py
@@ -42,6 +42,8 @@ class ReportingController(BaseController):
 
             extra_vars = {
                 'organisations': organisations,
+                'start_date': start_date,
+                'end_date': end_date,
                 'user_dict': get_action('user_show')({}, {'id': c.userobj.id})
             }
 
@@ -51,8 +53,6 @@ class ReportingController(BaseController):
                 extra_vars.update({
                     'org_id': org_id,
                     'org_title': org['title'],
-                    'start_date': start_date,
-                    'end_date': end_date,
                     'metrics': helpers.gather_metrics(org_id, start_date, end_date, COMMENT_NO_REPLY_MAX_DAYS, DATAREQUEST_OPEN_MAX_DAYS),
                     'datarequest_open_max_days': DATAREQUEST_OPEN_MAX_DAYS,
                     'comment_no_reply_max_days': COMMENT_NO_REPLY_MAX_DAYS


### PR DESCRIPTION
This PR addresses two issues:

1. Converting `.ini` configuration settings for `ckan.reporting.datarequest_open_max_days` and `ckan.reporting.comment_no_reply_max_days` to INT before usage
2. Pre-populating the start and end date of the report to the defaults

@duttonw & @ThrawnCA - for review please