### PR TITLE
[DQL2-35] Reporting Automated testing considerations

### DIFF
--- a/.docker/scripts/init-ext.sh
+++ b/.docker/scripts/init-ext.sh
@@ -10,9 +10,9 @@ pip install -r "/app/requirements.txt"
 pip install -r "/app/requirements-dev.txt"
 pip install -r "/app/ckan/default/src/ckanext-validation/requirements.txt"
 pip install -r "/app/ckan/default/src/ckanext-scheming/requirements.txt"
-pip install -r "/app/ckan/default/src/ckanext-odi-certificates/requirements.txt"
 pip install -r "/app/ckan/default/src/ckanext-data-qld-theme/requirements.txt"
 pip install -r "/app/ckan/default/src/ckanext-dcat/requirements.txt"
+pip install -r "/app/ckan/default/src/ckanext-ytp-comments/requirements.txt"
 python setup.py develop
 
 # Validate that the extension was installed correctly.

--- a/.docker/scripts/init.sh
+++ b/.docker/scripts/init.sh
@@ -24,5 +24,10 @@ paster --plugin=ckanext-archiver archiver init -c /app/ckan/default/production.i
 # Initialise the ckanext-qa tables
 paster --plugin=ckanext-qa qa init -c /app/ckan/default/production.ini
 
+# Initialise the Comments database tables
+paster --plugin=ckanext-ytp-comments initdb --config=/app/ckan/default/production.ini
+paster --plugin=ckanext-ytp-comments updatedb --c /app/ckan/default/production.ini
+paster --plugin=ckanext-ytp-comments init_notifications_db --c /app/ckan/default/production.ini
+
 # Create some base test data
 . /app/scripts/create-test-data.sh

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -94,7 +94,7 @@ ckan.redis.url = redis://redis:6379
 #       Add ``resource_proxy`` to enable resorce proxying and get around the
 #       same origin policy
 # @todo:setup Cleanup the list to use only required plugins.
-ckan.plugins = stats text_view image_view recline_view datastore datarequests data_qld data_qld_theme scheming_datasets validation odi_certificates dcat qa archiver report
+ckan.plugins = stats text_view image_view recline_view datastore data_qld_theme datarequests data_qld scheming_datasets validation dcat qa archiver report data_qld_reporting ytp_comments
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)
@@ -113,6 +113,7 @@ ckan.locale_default = en_AU
 ckan.locale_order = en pt_BR ja it cs_CZ ca es fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv
 ckan.locales_offered =
 ckan.locales_filtered_out = en_AU
+ckan.display_timezone = Australia/Queensland
 
 ## Feeds Settings
 
@@ -194,18 +195,24 @@ scheming.presets = ckanext.scheming:presets.json ckanext.data_qld:presets.json
 #   The is_fallback setting may be changed as well. Defaults to false:
 scheming.dataset_fallback = false
 
+## ckanext-datarequests settings
+# Enable or disable the comments system by setting up the ckan.datarequests.comments property in the configuration file (by default, the comments system is enabled).
+ckan.datarequests.comments = true
+# Enable or disable a badge to show the number of data requests in the menu by setting up the ckan.datarequests.show_datarequests_badge property in the configuration file (by default, the badge is not shown).
+ckan.datarequests.show_datarequests_badge = true
+# Enable or disable description as a required field on data request forms
+ckan.datarequests.description_required = true
+# Default organisation used for new data requests
+ckan.datarequests.default_organisation = open-data-administration-data-requests
 
-# ODI config settings
-# The odi api certificate base url to search for certificates
-ckan.odi_certificates.certificate_base_url = https://certificates.theodi.org/en/datasets?
-# The odi api query parameters used to search for the certificate img. JSON object gets converted to HTML query parameters e.g. datasetUrl=https://datasetUrl&type=badge&format=png
-ckan.odi_certificates.certificate_img_query_parameters = {"datasetUrl":"", "format":"png", "type":"badge"}
-# The odi api query parameters used to for the certificate link to the ODI certificate website. JSON object gets converted to HTML query parameters e.g. datasetUrl=https://datasetUrl
-ckan.odi_certificates.certificate_link_query_parameters = {"datasetUrl":""}
-# The dataset base url of the CKAN instance
-ckan.odi_certificates.dataset_base_url = https://data.qld.gov.au
-
-
+# YTP Comments
+ckan.comments.moderation = False
+ckan.comments.moderation.first_only = False
+ckan.comments.threaded_comments = True
+ckan.comments.users_can_edit = False
+ckan.comments.check_for_profanity = True
+ckan.comments.bad_words_file = /app/ckan/default/src/ckanext-ytp-comments/ckanext/ytp/comments/bad_words.txt
+ckan.comments.show_comments_tab_page = True
 
 ## Logging configuration
 [loggers]

--- a/ckanext/data_qld/reporting/helpers/helpers.py
+++ b/ckanext/data_qld/reporting/helpers/helpers.py
@@ -45,7 +45,8 @@ def get_report_date_range(request):
     if end_date:
         end_date = toolkit.h.date_str_to_datetime(end_date)
     else:
-        end_date = datetime.now()
+        ckan_timezone = toolkit.config.get('ckan.display_timezone', None)
+        end_date = datetime.now(pytz.timezone(ckan_timezone))
 
     return start_date.date().isoformat(), end_date.date().isoformat()
 

--- a/ckanext/data_qld/templates/reporting/index.html
+++ b/ckanext/data_qld/templates/reporting/index.html
@@ -51,42 +51,42 @@
             <tbody>
                 <tr>
                     <td>{{ _('Dataset') }} {{ _('followers') }}</td>
-                    <td>{{ metrics.dataset_followers }}</td>
+                    <td id="dataset_followers" >{{ metrics.dataset_followers }}</td>
                     <td>-</td>
                 </tr>
                 <tr>
                     <td>{{ _('Organization') }} {{ _('followers') }}</td>
-                    <td>{{ metrics.organisation_followers }}</td>
+                    <td id="organisation_followers" >{{ metrics.organisation_followers }}</td>
                     <td>-</td>
                 </tr>
                 <tr>
                     <td>{{ _('Dataset') }} comments</td>
-                    <td>{{ metrics.dataset_comments }}</td>
+                    <td id="dataset_comments" >{{ metrics.dataset_comments }}</td>
                     <td>-</td>
                 </tr>
                 <tr>
                     <td>{{ _('Dataset') }} comment {{ _('followers') }}</td>
-                    <td>{{ metrics.dataset_comment_followers }}</td>
+                    <td id="dataset_comment_followers" >{{ metrics.dataset_comment_followers }}</td>
                     <td>-</td>
                 </tr>
                 <tr>
                     <td>Datasets with at least one comment {{ _('follower') }}</td>
-                    <td>{{ metrics.datasets_min_one_comment_follower }}</td>
+                    <td id="datasets_min_one_comment_follower"  >{{ metrics.datasets_min_one_comment_follower }}</td>
                     <td>-</td>
                 </tr>
                 <tr>
                     <td align="left">Data requests</td>
-                    <td>{{ metrics.datarequests.total }}</td>
+                    <td id="datarequests_total">{{ metrics.datarequests.total }}</td>
                     <td>-</td>
                 </tr>
                 <tr>
                     <td>Data request comments</td>
-                    <td>{{ metrics.datarequest_comments }}</td>
+                    <td id="datarequest_comments" >{{ metrics.datarequest_comments }}</td>
                     <td>-</td>
                 </tr>
                 <tr>
                     <td>Data requests with at least one comment {{ _('follower') }}</td>
-                    <td>{{ metrics.datarequests_min_one_comment_follower }}</td>
+                    <td id="datarequests_min_one_comment_follower" >{{ metrics.datarequests_min_one_comment_follower }}</td>
                     <td>-</td>
                 </tr>
 
@@ -114,8 +114,8 @@
 
                 <tr>
                     <td>Closed data requests (circumstances broken out below)</td>
-                    <td>{{ datarequests.closed }}</td>
-                    <td>{{ datarequests.average_overall }}</td>
+                    <td id="datarequests_closed" >{{ datarequests.closed }}</td>
+                    <td id="datarequests_average_overall" >{{ datarequests.average_overall }}</td>
                 </tr>
 
                 {% snippet "reporting/snippets/closed_datarequest_metrics.html",
@@ -127,16 +127,16 @@
                 {% with no_accepted_dataset = datarequests.no_circumstance['no_accepted_dataset'] %}
                 <tr class="closing-circumstance">
                     <td>Closed no accepted dataset (pre-July 2020)</td>
-                    <td>{{ no_accepted_dataset.count }}</td>
-                    <td>{{ no_accepted_dataset.average|default('-') }}</td>
+                    <td id="no_accepted_dataset_count" >{{ no_accepted_dataset.count }}</td>
+                    <td id="no_accepted_dataset_average" >{{ no_accepted_dataset.average|default('-') }}</td>
                 </tr>
                 {% endwith %}
 
                 {% with accepted_dataset = datarequests.no_circumstance['accepted_dataset'] %}
                 <tr class="closing-circumstance">
                     <td>Closed accepted dataset (pre-July 2020)</td>
-                    <td>{{ accepted_dataset.count }}</td>
-                    <td>{{ accepted_dataset.average|default('-') }}</td>
+                    <td id="accepted_dataset_count" >{{ accepted_dataset.count }}</td>
+                    <td id="accepted_dataset_average" >{{ accepted_dataset.average|default('-') }}</td>
                 </tr>
                 {% endwith %}
             </tbody>

--- a/ckanext/data_qld/templates/reporting/index.html
+++ b/ckanext/data_qld/templates/reporting/index.html
@@ -49,44 +49,44 @@
                 <th width="15%">Avg. time* (days)</th>
             </thead>
             <tbody>
-                <tr>
-                    <td>{{ _('Dataset') }} {{ _('followers') }}</td>
-                    <td id="dataset_followers" >{{ metrics.dataset_followers }}</td>
+                <tr id="dataset-followers" >
+                    <td class="metric-title" >{{ _('Dataset') }} {{ _('followers') }}</td>
+                    <td class="metric-data" >{{ metrics.dataset_followers }}</td>
                     <td>-</td>
                 </tr>
-                <tr>
-                    <td>{{ _('Organization') }} {{ _('followers') }}</td>
-                    <td id="organisation_followers" >{{ metrics.organisation_followers }}</td>
+                <tr id="organisation-followers" >
+                    <td class="metric-title" >{{ _('Organization') }} {{ _('followers') }}</td>
+                    <td class="metric-data" >{{ metrics.organisation_followers }}</td>
                     <td>-</td>
                 </tr>
-                <tr>
-                    <td>{{ _('Dataset') }} comments</td>
-                    <td id="dataset_comments" >{{ metrics.dataset_comments }}</td>
+                <tr id="dataset-comments" >
+                    <td class="metric-title" >{{ _('Dataset') }} comments</td>
+                    <td class="metric-data" >{{ metrics.dataset_comments }}</td>
                     <td>-</td>
                 </tr>
-                <tr>
-                    <td>{{ _('Dataset') }} comment {{ _('followers') }}</td>
-                    <td id="dataset_comment_followers" >{{ metrics.dataset_comment_followers }}</td>
+                <tr id="dataset-comment-followers" >
+                    <td class="metric-title" >{{ _('Dataset') }} comment {{ _('followers') }}</td>
+                    <td class="metric-data" >{{ metrics.dataset_comment_followers }}</td>
                     <td>-</td>
                 </tr>
-                <tr>
-                    <td>Datasets with at least one comment {{ _('follower') }}</td>
-                    <td id="datasets_min_one_comment_follower"  >{{ metrics.datasets_min_one_comment_follower }}</td>
+                <tr id="datasets-min-one-comment-follower" >
+                    <td class="metric-title" >Datasets with at least one comment {{ _('follower') }}</td>
+                    <td class="metric-data" >{{ metrics.datasets_min_one_comment_follower }}</td>
                     <td>-</td>
                 </tr>
-                <tr>
-                    <td align="left">Data requests</td>
-                    <td id="datarequests_total">{{ metrics.datarequests.total }}</td>
+                <tr id="datarequests-total" >
+                    <td class="metric-title" align="left">Data requests</td>
+                    <td class="metric-data" >{{ metrics.datarequests.total }}</td>
                     <td>-</td>
                 </tr>
-                <tr>
-                    <td>Data request comments</td>
-                    <td id="datarequest_comments" >{{ metrics.datarequest_comments }}</td>
+                <tr id="datarequest-comments" >
+                    <td class="metric-title" >Data request comments</td>
+                    <td class="metric-data" >{{ metrics.datarequest_comments }}</td>
                     <td>-</td>
                 </tr>
-                <tr>
-                    <td>Data requests with at least one comment {{ _('follower') }}</td>
-                    <td id="datarequests_min_one_comment_follower" >{{ metrics.datarequests_min_one_comment_follower }}</td>
+                <tr id="datarequests-min-one-comment-follower" >
+                    <td class="metric-title" >Data requests with at least one comment {{ _('follower') }}</td>
+                    <td class="metric-data" >{{ metrics.datarequests_min_one_comment_follower }}</td>
                     <td>-</td>
                 </tr>
 
@@ -112,10 +112,10 @@
                     count=metrics.open_datarequests_no_comments_after_x_days|length,
                     link='/dashboard/reporting/datarequests/' + org_id + '/no-comments?start_date={0}&end_date={1}'.format(start_date, end_date) %}
 
-                <tr>
-                    <td>Closed data requests (circumstances broken out below)</td>
-                    <td id="datarequests_closed" >{{ datarequests.closed }}</td>
-                    <td id="datarequests_average_overall" >{{ datarequests.average_overall }}</td>
+                <tr id="closed-data-requests" >
+                    <td class="metric-title" >Closed data requests (circumstances broken out below)</td>
+                    <td id="datarequests-closed" class="metric-data" >{{ datarequests.closed }}</td>
+                    <td id="datarequests-average-overall" class="metric-data" >{{ datarequests.average_overall }}</td>
                 </tr>
 
                 {% snippet "reporting/snippets/closed_datarequest_metrics.html",
@@ -125,18 +125,18 @@
                     end_date=end_date %}
 
                 {% with no_accepted_dataset = datarequests.no_circumstance['no_accepted_dataset'] %}
-                <tr class="closing-circumstance">
-                    <td>Closed no accepted dataset (pre-July 2020)</td>
-                    <td id="no_accepted_dataset_count" >{{ no_accepted_dataset.count }}</td>
-                    <td id="no_accepted_dataset_average" >{{ no_accepted_dataset.average|default('-') }}</td>
+                <tr id="closed-no-accepted-dataset" class="closing-circumstance">
+                    <td class="metric-title" >Closed no accepted dataset (pre-July 2020)</td>
+                    <td id="no-accepted-dataset-count" class="metric-data" >{{ no_accepted_dataset.count }}</td>
+                    <td id="no-accepted-dataset-average" class="metric-data" >{{ no_accepted_dataset.average|default('-') }}</td>
                 </tr>
                 {% endwith %}
 
                 {% with accepted_dataset = datarequests.no_circumstance['accepted_dataset'] %}
-                <tr class="closing-circumstance">
-                    <td>Closed accepted dataset (pre-July 2020)</td>
-                    <td id="accepted_dataset_count" >{{ accepted_dataset.count }}</td>
-                    <td id="accepted_dataset_average" >{{ accepted_dataset.average|default('-') }}</td>
+                <tr id="closed-accepted-dataset" class="closing-circumstance">
+                    <td class="metric-title" >Closed accepted dataset (pre-July 2020)</td>
+                    <td id="accepted-dataset-count" class="metric-data" >{{ accepted_dataset.count }}</td>
+                    <td id="accepted-dataset-average" class="metric-data" >{{ accepted_dataset.average|default('-') }}</td>
                 </tr>
                 {% endwith %}
             </tbody>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,12 +3,16 @@ behaving==1.5.6
 flake8==3.8.3
 nose==1.3.7
 splinter>=0.13.0
+xlrd==1.0.0
+python-magic==0.4.12
 messytables==0.15.2
+progressbar==2.3
 -e git+https://github.com/qld-gov-au/ckanext-datarequests@develop#egg=ckanext-datarequests
 -e git+https://github.com/frictionlessdata/ckanext-validation#egg=ckanext-validation
 -e git+https://github.com/qld-gov-au/ckanext-data-qld-theme@develop#egg=ckanext-data-qld-theme
--e git+https://github.com/qld-gov-au/ckanext-odi-certificates@develop#egg=ckanext-odi-certificates
 -e git+https://github.com/ckan/ckanext-dcat.git#egg=ckanext-dcat
 -e git+https://github.com/qld-gov-au/ckanext-archiver@develop#egg=ckanext-archiver
 -e git+https://github.com/qld-gov-au/ckanext-report@develop#egg=ckanext-report
 -e git+https://github.com/qld-gov-au/ckanext-qa@develop#egg=ckanext-qa
+-e git+https://github.com/qld-gov-au/ckanext-ytp-comments@develop#egg=ckanext-ytp-comments
+-e git+https://github.com/qld-gov-au/ckanext-datarequests@develop#egg=ckanext-datarequests

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -44,6 +44,21 @@ PERSONAS = {
         name=u'test_org_member',
         email=u'test_org_member@localhost',
         password=u'password'
+    ),
+    'DataRequestOrgAdmin': dict(
+        name=u'dr_admin',
+        email=u'dr_admin@localhost',
+        password=u'password'
+    ),
+    'DataRequestOrgEditor': dict(
+        name=u'dr_editor',
+        email=u'dr_editor@localhost',
+        password=u'password'
+    ),
+    'DataRequestOrgMember': dict(
+        name=u'dr_member',
+        email=u'dr_member@localhost',
+        password=u'password'
     )
 }
 

--- a/test/features/reporting.feature
+++ b/test/features/reporting.feature
@@ -26,43 +26,51 @@ Feature: Reporting
         When I log in
         And I go to my reports page
         And I press the element with xpath "//button[contains(string(), 'Show')]"
-        Then I should see an element with xpath "//td[@id='datarequests_total' and string()='0']"
+        Then I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-title') and string()='Data requests' and position()=1]"
+        Then I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-data') and string()='0' and position()=2]"
         When I create a datarequest
         And I go to my reports page
         And I press the element with xpath "//button[contains(string(), 'Show')]"
-        Then I should see an element with xpath "//td[@id='datarequests_total' and string()='1']"
+        Then I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-title') and string()='Data requests' and position()=1]"
+        Then I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-data') and string()='1' and position()=2]"
 
 
     Scenario: As an admin user of my organisation, when I view my organisation report, I can verify the number of dataset followers is correct and increments
         Given "TestOrgAdmin" as the persona
         When I log in
         And I go to my reports page
-        Then I should see an element with xpath "//td[@id='dataset_followers' and string()='0']" 
+        Then I should see an element with xpath "//tr[@id='dataset-followers']/td[contains(@class, 'metric-title') and string()='Dataset followers' and position()=1]"
+        Then I should see an element with xpath "//tr[@id='dataset-followers']/td[contains(@class, 'metric-data') and string()='0' and position()=2]"
         When I visit "/dataset/warandpeace"
         And I press the element with xpath "//a[@class='btn btn-success' and contains(string(), 'Follow')]"
         And I go to my reports page
-        Then I should see an element with xpath "//td[@id='dataset_followers' and string()='1']"  
+        Then I should see an element with xpath "//tr[@id='dataset-followers']/td[contains(@class, 'metric-title') and string()='Dataset followers' and position()=1]"
+        Then I should see an element with xpath "//tr[@id='dataset-followers']/td[contains(@class, 'metric-data') and string()='1' and position()=2]" 
 
 
     Scenario: As an admin user of my organisation, when I view my organisation report, I can verify the number of dataset comments is correct and increments
         Given "TestOrgAdmin" as the persona
         When I log in
         And I go to my reports page
-        Then I should see an element with xpath "//td[@id='dataset_comments' and string()='0']" 
+        Then I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-title') and string()='Dataset comments' and position()=1]"
+        Then I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-data') and string()='0' and position()=2]"  
         When I go to dataset "warandpeace" comments
         And I submit a comment with subject "Test subject" and comment "This is a test comment"
         And I go to my reports page
-        Then I should see an element with xpath "//td[@id='dataset_comments' and string()='1']"
+        Then I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-title') and string()='Dataset comments' and position()=1]"
+        Then I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-data') and string()='1' and position()=2]"  
 
 
     Scenario: As an admin user of my organisation, when I view my organisation report, I can verify the number of data request comments is correct and increments
         Given "TestOrgAdmin" as the persona
         When I log in
         And I go to my reports page
-        Then I should see an element with xpath "//td[@id='datarequest_comments' and string()='0']" 
+        Then I should see an element with xpath "//tr[@id='datarequest-comments']/td[contains(@class, 'metric-title') and string()='Data request comments' and position()=1]"
+        Then I should see an element with xpath "//tr[@id='datarequest-comments']/td[contains(@class, 'metric-data') and string()='0' and position()=2]"  
         When I go to datarequest page
         And I click the link with text that contains "Test Request"
         And I click the link with text that contains "Comments"
         And I submit a comment with subject "Test subject" and comment "This is a test comment"
         And I go to my reports page
-        Then I should see an element with xpath "//td[@id='datarequest_comments' and string()='1']"
+        Then I should see an element with xpath "//tr[@id='datarequest-comments']/td[contains(@class, 'metric-title') and string()='Data request comments' and position()=1]"
+        Then I should see an element with xpath "//tr[@id='datarequest-comments']/td[contains(@class, 'metric-data') and string()='1' and position()=2]" 

--- a/test/features/reporting.feature
+++ b/test/features/reporting.feature
@@ -1,0 +1,68 @@
+@reporting
+Feature: Reporting
+
+    Scenario Outline: As a user with admin or editor role capacity of an organisation, I can view 'My Reports' tab in the dashboard and show the organisation report with filters
+        Given "<User>" as the persona
+        When I log in
+        And I visit "dashboard"
+        And I click the link with text that contains "My Reports"
+        Then I should see an element with id "organisation"
+        And I should see an element with id "start_date"
+        And I fill in "start_date" with "01-01-2019"
+        And I should see an element with id "end_date"
+        And I fill in "end_date" with "01-01-2020"
+        When I press the element with xpath "//button[contains(string(), 'Show')]"
+        Then I should see "Organisation: Test" within 1 seconds
+        And I should see "01/01/2019 - 01/01/2020" within 1 seconds
+    
+        Examples: Users  
+        | User              |
+        | TestOrgAdmin      |
+        | TestOrgEditor     |
+
+
+    Scenario: As a data request organisation admin, when I view my organisation report, I can verify the number of data requests is correct and increments
+        Given "DataRequestOrgAdmin" as the persona
+        When I log in
+        And I go to my reports page
+        And I press the element with xpath "//button[contains(string(), 'Show')]"
+        Then I should see an element with xpath "//td[@id='datarequests_total' and string()='0']"
+        When I create a datarequest
+        And I go to my reports page
+        And I press the element with xpath "//button[contains(string(), 'Show')]"
+        Then I should see an element with xpath "//td[@id='datarequests_total' and string()='1']"
+
+
+    Scenario: As an admin user of my organisation, when I view my organisation report, I can verify the number of dataset followers is correct and increments
+        Given "TestOrgAdmin" as the persona
+        When I log in
+        And I go to my reports page
+        Then I should see an element with xpath "//td[@id='dataset_followers' and string()='0']" 
+        When I visit "/dataset/warandpeace"
+        And I press the element with xpath "//a[@class='btn btn-success' and contains(string(), 'Follow')]"
+        And I go to my reports page
+        Then I should see an element with xpath "//td[@id='dataset_followers' and string()='1']"  
+
+
+    Scenario: As an admin user of my organisation, when I view my organisation report, I can verify the number of dataset comments is correct and increments
+        Given "TestOrgAdmin" as the persona
+        When I log in
+        And I go to my reports page
+        Then I should see an element with xpath "//td[@id='dataset_comments' and string()='0']" 
+        When I go to dataset "warandpeace" comments
+        And I submit a comment with subject "Test subject" and comment "This is a test comment"
+        And I go to my reports page
+        Then I should see an element with xpath "//td[@id='dataset_comments' and string()='1']"
+
+
+    Scenario: As an admin user of my organisation, when I view my organisation report, I can verify the number of data request comments is correct and increments
+        Given "TestOrgAdmin" as the persona
+        When I log in
+        And I go to my reports page
+        Then I should see an element with xpath "//td[@id='datarequest_comments' and string()='0']" 
+        When I go to datarequest page
+        And I click the link with text that contains "Test Request"
+        And I click the link with text that contains "Comments"
+        And I submit a comment with subject "Test subject" and comment "This is a test comment"
+        And I go to my reports page
+        Then I should see an element with xpath "//td[@id='datarequest_comments' and string()='1']"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -48,3 +48,79 @@ def title_random_text(context):
     context.execute_steps(u"""
         When I fill in "title" with "Test Title {0}"
     """.format(random.randrange(1000)))
+
+
+@step('I log in and go to datarequest page')
+def log_in_go_to_datarequest_page(context):
+
+    assert context.persona
+    context.execute_steps(u"""
+        When I go to homepage
+        And I click the link with text that contains "Log in"
+        And I log in
+        And I go to datarequest page
+    """)
+
+
+@step('I go to datarequest page')
+def go_to_datarequest_page(context):
+    when_i_visit_url(context, '/datarequest')
+
+
+@step('I log in and create a datarequest')
+def log_in_create_a_datarequest(context):
+
+    assert context.persona
+    context.execute_steps(u"""
+        When I log in and go to datarequest page
+        And I create a datarequest
+    """)
+
+
+@step('I create a datarequest')
+def create_datarequest(context):
+
+    assert context.persona
+    context.execute_steps(u"""
+        When I go to datarequest page
+        And I click the link with text that contains "Add data request"
+        And I fill in title with random text
+        And I fill in "description" with "Test description"
+        And I press the element with xpath "//button[contains(string(), 'Create data request')]"
+    """)
+
+
+@step('I go to my reports page')
+def go_to_reporting_page(context):
+    when_i_visit_url(context, '/dashboard/reporting')
+
+
+@step(u'I go to dataset "{name}"')
+def go_to_dataset(context, name):
+    when_i_visit_url(context, '/dataset/' + name)
+
+
+@step(u'I go to dataset "{name}" comments')
+def go_to_dataset_comments(context, name):
+    context.execute_steps(u"""
+        When I go to dataset "%s"
+        And I click the link with text that contains "Comments"
+    """ % (name))
+
+
+@step(u'I submit a comment with subject "{subject}" and comment "{comment}"')
+def submit_comment_with_subject_and_comment(context, subject, comment):
+    """
+    There can be multiple comment forms per page (add, edit, reply) each with fields named "subject" and "comment"
+    This step overcomes a limitation of the fill() method which only fills a form field by name
+    :param context:
+    :param subject:
+    :param comment:
+    :return:
+    """
+    context.browser.execute_script(
+        "document.querySelector('form#comment_form input[name=\"subject\"]').value = '%s';" % subject)
+    context.browser.execute_script(
+        "document.querySelector('form#comment_form textarea[name=\"comment\"]').value = '%s';" % comment)
+    context.browser.execute_script(
+        "document.querySelector('form#comment_form .form-actions input[type=\"submit\"]').click();")


### PR DESCRIPTION
- Added data request and ytp-comments config settings
- Created test data for data request
- Fixed issue with end_date on report not using ckan display timezone
- Added element ids to use for reporting testing
- Added new BDD steps for data requests, comments and reporting
- Added new reporting.feature for BDD tests
- Removed odi-certificate extension dependency
- Adding ytp-comments extension and dependencies for BDD tests
- Added extension data request and created test data and steps

@duttonw @ThrawnCA Here are the BDD tests for your review.
