### PR TITLE
UAT remediation [DQL3-63][DQL3-75]

### DIFF
--- a/ckanext/data_qld/resource_freshness/helpers/helpers.py
+++ b/ckanext/data_qld/resource_freshness/helpers/helpers.py
@@ -101,7 +101,7 @@ def process_next_update_due(data_dict):
 
 
 def process_nature_of_change(resource_dict):
-    if 'nature_of_change' in resource_dict:
+    if 'nature_of_change' in resource_dict and not data_qld_helpers.user_has_admin_access(True):
         del resource_dict['nature_of_change']
 
 

--- a/ckanext/data_qld/resource_freshness/validation.py
+++ b/ckanext/data_qld/resource_freshness/validation.py
@@ -52,7 +52,7 @@ def validate_next_update_due(keys, flattened_data, errors, context):
             today = dt.datetime.now(h.get_display_timezone())
             if next_update_due.date() <= today.date():
                 errors[keys].append(_("Valid date in the future is required"))
-        elif data_qld_helpers.is_api_request():
+        elif data_qld_helpers.is_api_request() or not current_next_update_due:
             flattened_data[keys] = resource_freshness_helpers.recalculate_next_update_due_date(flattened_data, update_frequency, errors, context)
         else:
             errors[keys].append(_('Missing value'))


### PR DESCRIPTION
Hi @duttonw @ThrawnCA ,

Here is the PR for the following stories.
[Enable package_patch API call to handle "Nature of change to data" mandatory requirement](https://salsadigital.atlassian.net/browse/DQL3-63)
- Added logic to check user access to display `nature_of_change`
- This should fix the datastore issue which uses package_patch

[Handle resource validation for existing datasets when the user changes metadata without updating data](https://salsadigital.atlassian.net/browse/DQL3-75)
- Added logic to calculate `next_update_due` if there is no current value set