### PR TITLE
Xloader datastore fix

### DIFF
--- a/ckanext/data_qld/resource_freshness/helpers/helpers.py
+++ b/ckanext/data_qld/resource_freshness/helpers/helpers.py
@@ -71,7 +71,11 @@ def check_resource_data(current_resource, updated_resource, context):
 
     if not data_updated:
         # Compare urls
-        updated_resource_url = updated_resource.get('url', '')
+        if updated_resource.get('url_type', '') == 'upload':
+            # Strip the full url for resources of type 'upload' to get filename for compare
+            updated_resource_url = updated_resource.get('url', '').rsplit('/')[-1]
+        else:
+            updated_resource_url = updated_resource.get('url', '')
         if current_resource.get('url_type', '') == 'upload':
             # Strip the full url for resources of type 'upload' to get filename for compare
             current_resource_url = current_resource.get('url', '').rsplit('/')[-1]


### PR DESCRIPTION
Hi @duttonw ,
Here is the fix for manually submitting a resource to the datastore.
There was a bug in the resource data updated logic which caused a downstream validator to trigger the missing 'nature_of_change' error message which was not required.