### PR TITLE
Package delete API issue with deletion reason

### DIFF
--- a/ckanext/data_qld/dataset_deletion/helpers.py
+++ b/ckanext/data_qld/dataset_deletion/helpers.py
@@ -1,43 +1,45 @@
 # encoding: utf-8
 
-import json
 import logging
 
-from ckantoolkit import request, get_action, ValidationError, get_endpoint, h
+from ckantoolkit import request, get_action, ValidationError, h
+from ckanext.data_qld import helpers as data_qld_helpers
 
 log = logging.getLogger(__name__)
 
 
-def add_deletion_of_dataset_reason(data_dict):
-    deletion_reason = ''
-    if get_endpoint()[1] == 'action':
-        body = json.loads(request.body)
-        deletion_reason = body.get('deletion_reason', '')
+def add_deletion_of_dataset_reason(context, data_dict):
+    dataset_id = data_dict.get('id')
+    is_api_request = data_qld_helpers.is_api_request()
+
+    if is_api_request:
+        # API Controller/View will send all of body data in the data_dict
+        # Retrieve value from data_dict
+        deletion_reason = data_dict.get('deletion_reason')
     else:
-        params = request.params.items()
-        for param in params:
-            if 'deletion_reason' in param:
-                deletion_reason = param[1]
+        # UI Controller/View will only send the id in the data_dict
+        # Retrieve value from request params
+        deletion_reason = request.params.get('deletion_reason')
 
     if not deletion_reason:
-        if get_endpoint()[1] == 'action':
+        if is_api_request:
             raise ValidationError('Missing deletion_reason field.')
         else:
             h.flash_error('Missing deletion reason.')
-            return h.redirect_to('/dataset/edit/' + data_dict.id)
+            return h.redirect_to('/dataset/edit/' + dataset_id)
 
     if len(deletion_reason) < 10:
-        if get_endpoint()[1] == 'action':
+        if is_api_request:
             raise ValidationError('Field deletion_reason must not less than 10 characters.')
         else:
             h.flash_error('Deletion reason must not less than 10 characters.')
-            return h.redirect_to('/dataset/edit/' + data_dict.id)
+            return h.redirect_to('/dataset/edit/' + dataset_id)
 
     if len(deletion_reason) > 250:
-        if get_endpoint()[1] == 'action':
+        if is_api_request:
             raise ValidationError('Field deletion_reason must not more than 250 characters.')
         else:
             h.flash_error('Deletion reason must not more than 250 characters.')
-            return h.redirect_to('/dataset/edit/' + data_dict.id)
+            return h.redirect_to('/dataset/edit/' + dataset_id)
 
-    get_action('package_patch')({}, {'id': data_dict.id, 'deletion_reason': deletion_reason})
+    get_action('package_patch')(context, {'id': dataset_id, 'deletion_reason': deletion_reason})

--- a/ckanext/data_qld/plugin.py
+++ b/ckanext/data_qld/plugin.py
@@ -178,8 +178,8 @@ class DataQldPlugin(MixinPlugin, plugins.SingletonPlugin):
             resource_freshness_helpers.process_next_update_due(data_dict)
         return search_results
 
-    def delete(self, data_dict):
-        dataset_deletion_helpers.add_deletion_of_dataset_reason(data_dict)
+    def after_delete(self, context, data_dict):
+        dataset_deletion_helpers.add_deletion_of_dataset_reason(context, data_dict)
 
     # IResourceController
     def before_create(self, context, data_dict):


### PR DESCRIPTION
Hi @duttonw @ThrawnCA ,

I am not sure if you guys are aware but I noticed in our QA environment the `package_delete` API is broken and throwing a `*** AttributeError: 'CSRFAwareRequest' object has no attribute 'body'` error in the deletion reason helper `add_deletion_of_dataset_reason` on line 14 `body = json.loads(request.body)`
I am not sure when the body attribute was removed from the request object but I have refactored the code with a different approach to not rely on the request object for the API.

Initially, this helper was called from the `IPackageContoller` interface `delete` which only has the package entity object.
This has been updated to use another interface `after_delete` with the `data_dict` as a parameter with the `deletion_reason` data we require.

I also refactored some code while there.

You can test your current dev environment to confirm that the package_delete API returns a 500 Internal Server error.