### PR TITLE
QOL-8842 test cleanup

### DIFF
--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -97,7 +97,7 @@ add_user_if_needed walker "Walker" walker@localhost
 
 # Create test dataset with our standard fields
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "test-dataset", "owner_org": "'"${TEST_ORG_ID}"'",
+    --data '{"name": "test-dataset", "owner_org": "'"${TEST_ORG_ID}"'", "private": true,
 "update_frequency": "monthly", "author_email": "admin@localhost", "version": "1.0",
 "license_id": "other-open", "data_driven_application": "NO", "security_classification": "PUBLIC",
 "notes": "test", "de_identified_data": "NO"}' \

--- a/.env
+++ b/.env
@@ -23,3 +23,6 @@ ALLOW_UNIT_FAIL=0
 
 # Flag to allow BDD tests failures.
 ALLOW_BDD_FAIL=0
+
+CKAN_REPO=qld-gov-au/ckan
+CKAN_VERSION=ckan-2.9.5-qgov.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: [ckan-2.8.8-qgov.5, qgov-master-2.9.5]
+        ckan-version: [ckan-2.8.8-qgov.5, ckan-2.9.5-qgov.4]
 
     name: Continuous Integration build on CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,10 @@ services:
     networks:
       - amazeeio-network
       - default
+    extra_hosts:
+      - "www.googletagmanager.com:127.0.0.1"
+      - "fonts.gstatic.com:127.0.0.1"
+      - "gravatar.com:127.0.0.1"
 
 volumes:
   solr-data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       - amazeeio-network
       - default
     extra_hosts:
+      # point some unnecessary domains at localhost
       - "www.googletagmanager.com:127.0.0.1"
       - "fonts.gstatic.com:127.0.0.1"
       - "gravatar.com:127.0.0.1"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ progressbar==2.5
 
 -e git+https://github.com/ckan/ckanext-dcat.git@v1.1.3#egg=ckanext-dcat
 -e git+https://github.com/ckan/ckanext-scheming.git@release-2.1.0#egg=ckanext-scheming
--e git+https://github.com/qld-gov-au/ckan-ex-qgov.git@4.0.2#egg=ckanext-qgov
+-e git+https://github.com/qld-gov-au/ckan-ex-qgov.git@5.0.0#egg=ckanext-qgov
 -e git+https://github.com/qld-gov-au/ckanext-archiver.git@2.1.1-qgov.8#egg=ckanext-archiver
 -e git+https://github.com/qld-gov-au/ckanext-csrf-filter.git@1.1.3#egg=ckanext-csrf-filter
 -e git+https://github.com/qld-gov-au/ckanext-datarequests.git@2.2.0-qgov#egg=ckanext-datarequests

--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -41,8 +41,7 @@ Feature: Comments
         Then I should see an element with xpath "//h3[contains(string(), 'Add a comment')]"
         Then I submit a comment with subject "Test Request" and comment "This is a test data request comment"
         When I wait for 5 seconds
-        Then I should receive a base64 email at "test_org_admin@localhost" containing "Data request subject: Test Request"
-        And I should receive a base64 email at "test_org_admin@localhost" containing "Comment: This is a test data request comment"
+        Then I should receive a base64 email at "test_org_admin@localhost" containing both "Data request subject: Test Request" and "Comment: This is a test data request comment"
 
     @comment-add @comment-profane
     Scenario: When a logged-in user submits a comment containing whitelisted profanity on a Dataset the comment should display within 10 seconds

--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -1,6 +1,7 @@
 @comments
 Feature: Comments
 
+    @unauthenticated
     Scenario: The Add Comment form should not display for a non-logged-in user - instead they see a 'Login to comment' button
         Given "Unauthenticated" as the persona
         When I go to dataset "warandpeace" comments
@@ -32,7 +33,7 @@ Feature: Comments
         Then I submit a comment with subject "Test subject" and comment "This is a test comment"
         Then I should see "This is a test comment" within 10 seconds
 
-    @comment-add @datarequest @comment-email
+    @comment-add @datarequest @email
     Scenario: When a logged-in user submits a comment on a Data Request the email should contain title and comment
         Given "CKANUser" as the persona
         When I log in
@@ -61,7 +62,7 @@ Feature: Comments
         Then I submit a comment with subject "Test subject" and comment "He had sheep, and oxen, and he asses, and menservants, and maidservants, and she asses, and camels."
         Then I should see "Comment blocked due to profanity" within 5 seconds
 
-    @comment-report
+    @comment-report @email
     Scenario: When a logged-in user reports a comment on a Dataset the comment should be marked as reported and an email sent to the admins of the organisation
         Given "TestOrgEditor" as the persona
         When I log in
@@ -70,7 +71,7 @@ Feature: Comments
         Then I should see "Reported" within 5 seconds
         Then I should receive a base64 email at "test_org_admin@localhost" containing "This comment has been flagged as inappropriate by a user"
 
-    @comment-report @datarequest
+    @comment-report @datarequest @email
     Scenario: When a logged-in user reports a comment on a Data Request the comment should be marked as reported and an email notification sent to the organisation admins
         Given "CKANUser" as the persona
         When I log in
@@ -112,6 +113,7 @@ Feature: Comments
         And I should see "Comment deleted by Test Admin." within 2 seconds
 
     @comment-tab
+    @unauthenticated
     Scenario: Non-logged in users should not see comment form in dataset tab
         Given "Unauthenticated" as the persona
         When I go to dataset "warandpeace"
@@ -120,10 +122,12 @@ Feature: Comments
     @comment-tab
     Scenario: Logged in users should not see comment form in dataset tab
         Given "CKANUser" as the persona
-        When I go to dataset "warandpeace"
+        When I log in
+        And I go to dataset "warandpeace"
         Then I should not see an element with id "comment_form"
 
     @comment-tab
+    @unauthenticated
     Scenario: Users should see comment tab on dataset
         Given "Unauthenticated" as the persona
         Then I go to dataset "warandpeace"

--- a/test/features/data_qld_theme.feature
+++ b/test/features/data_qld_theme.feature
@@ -1,10 +1,14 @@
 Feature: Theme customisations
 
+    @unauthenticated
     Scenario: Lato font is implemented on homepage
+        Given "Unauthenticated" as the persona
         When I go to homepage
         Then I should see an element with xpath "//link[contains(@href,'https://fonts.googleapis.com/css?family=Lato')]"
 
+    @unauthenticated
     Scenario: Organisation is in fact spelled Organisation (as opposed to Organization)
+        Given "Unauthenticated" as the persona
         When I go to organisation page
         Then I should see "Organisation"
         And I should not see "Organization"
@@ -35,11 +39,14 @@ Feature: Theme customisations
         And I should see "Some description or other"
         And I should see an element with xpath "//a[string() = 'read more' and contains(@href, '/organization/about/org-with-description')]"
 
+    @unauthenticated
     Scenario: Explore button does not exist on dataset detail page
+        Given "Unauthenticated" as the persona
         When I go to dataset page
         And I click the link with text that contains "A Wonderful Story"
         Then I should not see "Explore"
 
+    @unauthenticated
     Scenario: Explore button does not exist on dataset detail page
         When I go to organisation page
         Then I should see "Organisations are Queensland Government departments, other agencies or legislative entities responsible for publishing open data on this portal."
@@ -77,7 +84,9 @@ Feature: Theme customisations
         Then I should see an element with xpath "//a[contains(@href, '/datastore/dump/') and contains(@href, 'format=json') and contains(string(), 'JSON')]"
         Then I should see an element with xpath "//a[contains(@href, '/datastore/dump/') and contains(@href, 'format=xml') and contains(string(), 'XML')]"
 
+    @unauthenticated
     Scenario: When I encounter a 'resource not found' error page, it has a custom message
+        Given "Unauthenticated" as the persona
         When I go to "/dataset/nonexistent/resource/nonexistent"
         Then I should see "Sorry, the page you were looking for could not be found."
 
@@ -85,7 +94,9 @@ Feature: Theme customisations
         Then I should see an element with xpath "//div[contains(string(), 'was not found') or contains(string(), 'could not be found')]"
         And I should not see "Sorry, the page you were looking for could not be found."
 
+    @unauthenticated
     Scenario: When I go to the header URL, I can see the list of necessary assets
+        Given "Unauthenticated" as the persona
         When I go to "/header.html"
         Then I should see an element with xpath "//a[@href='/user/login' and contains(string(), 'Log in')]"
         And I should see an element with xpath "//a[@href='/user/register' and contains(string(), 'Register')]"

--- a/test/features/data_request.feature
+++ b/test/features/data_request.feature
@@ -1,15 +1,17 @@
 @datarequest
 Feature: Data Request
 
+    @unauthenticated
     Scenario: Data Requests are accessible via the /datarequest URL
+        Given "Unauthenticated" as the persona
         When I go to the data requests page
         Then the browser's URL should contain "/datarequest"
 
-
+    @unauthenticated
     Scenario: When visiting the datarequests page as a non-logged in user, the 'Add data request' button is not visible
+        Given "Unauthenticated" as the persona
         When I go to the data requests page
         Then I should not see an element with xpath "//a[contains(string(), 'Add data request', 'i')]"
-
 
     Scenario: Data requests submitted without a description will produce an error message
         Given "SysAdmin" as the persona
@@ -22,7 +24,6 @@ Feature: Data Request
         And I should see an element with the css selector "span.error-block" within 1 seconds
         And I should see "Description cannot be empty" within 1 seconds
 
-
     Scenario Outline: Data request creator and Sysadmin can see a 'Close' button on the data request detail page for opened data requests
         Given "<User>" as the persona
         When I log in and go to the data requests page
@@ -32,7 +33,6 @@ Feature: Data Request
         Examples: Users
         | User                  |
         | SysAdmin              |
-
 
     Scenario Outline: Non admin users cannot see a 'Close' button on the data request detail page for opened data requests
         Given "<User>" as the persona
@@ -48,13 +48,11 @@ Feature: Data Request
         | TestOrgEditor         |
         | TestOrgMember         |
 
-
     Scenario: Creating a new data request will show the data request afterward
         Given "TestOrgEditor" as the persona
         When I log in and create a datarequest
         Then I should see an element with xpath "//i[contains(@class, 'icon-unlock')]"
         And I should see an element with xpath "//a[contains(string(), 'Close')]"
-
 
     Scenario: Closing a data request will show the data request afterward
         Given "DataRequestOrgAdmin" as the persona
@@ -64,7 +62,6 @@ Feature: Data Request
         And I press the element with xpath "//button[contains(string(), 'Close data request')]"
         Then I should see an element with xpath "//i[contains(@class, 'icon-lock')]"
         And I should not see an element with xpath "//a[contains(string(), 'Close')]"
-
 
     Scenario: As an org admin I can re-open a closed data request
         Given "DataRequestOrgAdmin" as the persona

--- a/test/features/data_validation.feature
+++ b/test/features/data_validation.feature
@@ -13,7 +13,6 @@ Feature: Data Validation
         | TestOrgAdmin      |
         | TestOrgEditor     |
 
-
      Scenario: As any user, I can view the 'Data Schema' link in the 'Additional Info' table of the resource read-view page
        Given "SysAdmin" as the persona
         When I log in

--- a/test/features/de_identified_data.feature
+++ b/test/features/de_identified_data.feature
@@ -17,7 +17,6 @@ Feature: De-identified data
             | TestOrgAdmin  |
             | TestOrgEditor |
 
-
     Scenario Outline: An editor, admin or sysadmin user, when I go to the edit dataset page, the field field-de_identified_data should be visible with the correct values
         Given "<User>" as the persona
         When I log in
@@ -49,6 +48,7 @@ Feature: De-identified data
             | TestOrgAdmin  |
             | TestOrgEditor |
 
+    @unauthenticated
     Scenario: Unauthenticated user cannot view the de-identified data
         Given "Unauthenticated" as the persona
         When I go to "/dataset/warandpeace"
@@ -57,4 +57,3 @@ Feature: De-identified data
 
         And I go to "/api/3/action/package_show?id=warandpeace"
         Then I should not see an element with xpath "//body/*[contains(text(), '"de_identified_data":')]"
-

--- a/test/features/engagement_reporting.feature
+++ b/test/features/engagement_reporting.feature
@@ -21,7 +21,6 @@ Feature: Engagement Reporting
             | TestOrgAdmin  |
             | TestOrgEditor |
 
-
     Scenario: As a data request organisation admin, when I view my engagement report, I can verify the number of data requests is correct and increments
         Given "DataRequestOrgAdmin" as the persona
         When I log in
@@ -36,7 +35,6 @@ Feature: Engagement Reporting
         And I press the element with xpath "//button[contains(string(), 'Show')]"
         Then I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-title') and string()='Data requests' and position()=1]"
         Then I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-data') and string()='4' and position()=2]"
-
 
     Scenario: As an admin user of my organisation, when I view my engagement report, I can verify the number of dataset followers is correct and increments
         Given "ReportingOrgAdmin" as the persona
@@ -53,7 +51,6 @@ Feature: Engagement Reporting
         Then I should see an element with xpath "//tr[@id='dataset-followers']/td[contains(@class, 'metric-title') and string()='Dataset followers' and position()=1]"
         Then I should see an element with xpath "//tr[@id='dataset-followers']/td[contains(@class, 'metric-data') and string()='1' and position()=2]"
 
-
     Scenario: As an admin user of my organisation, when I view my engagement report, I can verify the number of dataset comments is correct and increments
         Given "ReportingOrgAdmin" as the persona
         When I log in
@@ -68,7 +65,6 @@ Feature: Engagement Reporting
         And I click the link with text that contains "Engagement Report"
         Then I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-title') and string()='Dataset comments' and position()=1]"
         Then I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-data') and string()='1' and position()=2]"
-
 
     Scenario: As an admin user of my organisation, when I view my engagement report, I can verify the number of data request comments is correct and increments
         Given "ReportingOrgAdmin" as the persona

--- a/test/features/google_analytics.feature
+++ b/test/features/google_analytics.feature
@@ -1,11 +1,15 @@
 @google-analytics
 Feature: GoogleAnalytics
 
+    @unauthenticated
     Scenario: When viewing the HTML source code of a CKAN page, the GTM snippet is visible
+        Given "Unauthenticated" as the persona
         When I go to homepage
         Then I should see an element with xpath "//script[@src='//www.googletagmanager.com/gtm.js?id=False']"
 
+    @unauthenticated
     Scenario: When viewing the HTML source code of a group, the appropriate metadata is visible
+        Given "Unauthenticated" as the persona
         When I go to group page
         And I resize the browser to 1024x2048
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Groups']"
@@ -28,7 +32,9 @@ Feature: GoogleAnalytics
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
         And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='guidelines']"
 
+    @unauthenticated
     Scenario: When viewing the HTML source code of an organisation, the appropriate metadata is visible
+        Given "Unauthenticated" as the persona
         When I go to organisation page
         And I resize the browser to 1024x2048
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Organisations']"

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -23,11 +23,15 @@ Feature: Group APIs
             | Organisation Admin  |
             | Walker              |
 
+    @unauthenticated
     Scenario: Group membership is not accessible anonymously
+        Given "Unauthenticated" as the persona
         When I view the "silly-walks" group API "including" users
         Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
 
+    @unauthenticated
     Scenario: Group overview is accessible to everyone
+        Given "Unauthenticated" as the persona
         When I go to "/group"
         Then I should see "silly-walks"
         When I view the "silly-walks" group API "not including" users

--- a/test/features/homepage.feature
+++ b/test/features/homepage.feature
@@ -2,7 +2,9 @@
 Feature: Homepage
 
     @homepage
+    @unauthenticated
     Scenario: Smoke test to ensure Homepage is accessible
+        Given "Unauthenticated" as the persona
         When I go to homepage
         Then I take a screenshot
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"

--- a/test/features/login_redirect.feature
+++ b/test/features/login_redirect.feature
@@ -23,12 +23,14 @@ Feature: Login Redirection
         Then I should see "Change details"
 
     @private_dataset
+    @unauthenticated
     Scenario: As an unauthenticated user, when I visit the URL of a private dataset I see the login page
         Given "Unauthenticated" as the persona
         When I visit "/dataset/test-dataset"
         Then I should see a login link
 
     @public_dataset
+    @unauthenticated
     Scenario: As an unauthenticated user, when I visit the URL of a public dataset I see the dataset without needing to login
         Given "Unauthenticated" as the persona
         When I visit "/dataset/warandpeace"

--- a/test/features/login_redirect.feature
+++ b/test/features/login_redirect.feature
@@ -22,16 +22,6 @@ Feature: Login Redirection
         When I log in directly
         Then I should see "Change details"
 
-    @dataset_setup
-    Scenario: As a Sysadmin I set the visibility of a public record to private for the following scenarios
-        Given "SysAdmin" as the persona
-        When I log in
-        Then I visit "/dataset/edit/test-dataset"
-        When I select "True" from "private"
-        And I fill in "author_email" with "test@example.com"
-        And I press "Update Dataset"
-        Then I should see an element with xpath "//span[contains(string(), 'Private')]"
-
     @private_dataset
     Scenario: As an unauthenticated user, when I visit the URL of a private dataset I see the login page
         Given "Unauthenticated" as the persona

--- a/test/features/navigation.feature
+++ b/test/features/navigation.feature
@@ -1,6 +1,8 @@
 Feature: Navigation
 
+    @unauthenticated
     Scenario: Check for the presence of the 'Request data' link in header when visiting as a non-logged in user
+        Given "Unauthenticated" as the persona
         When I go to homepage
         # Make the comparison case-insensitive
         Then I should see an element with xpath "//a[contains(translate(., 'RD', 'rd'), "request data")]"
@@ -13,10 +15,11 @@ Feature: Navigation
         Then I should see an element with xpath "//a[contains(translate(., 'RD', 'rd'), "request data")]"
 
     Scenario: Check for the presence of the 'Copyright' link in footer when visiting as a non-logged in user
+        Given "Unauthenticated" as the persona
         When I go to homepage
         Then I should see an element with xpath "//footer/div/ul/li/a[contains(string(), "Copyright")]"
 
     Scenario: Check for the presence of the 'Disclaimer' link in footer when visiting as a non-logged in user
+        Given "Unauthenticated" as the persona
         When I go to homepage
         Then I should see an element with xpath "//footer/div/ul/li/a[contains(string(), "Disclaimer")]"
-

--- a/test/features/organisations.feature
+++ b/test/features/organisations.feature
@@ -24,11 +24,15 @@ Feature: Organization APIs
             | Foodie        |
             | Group Admin   |
 
+    @unauthenticated
     Scenario: Organisation membership is not accessible anonymously
+        Given "Unauthenticated" as the persona
         When I view the "department-of-health" organisation API "including" users
         Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
 
+    @unauthenticated
     Scenario: Organisation overview is accessible to everyone
+        Given "Unauthenticated" as the persona
         When I go to organisation page
         Then I should see "Department of Health"
         When I view the "department-of-health" organisation API "not including" users

--- a/test/features/resource_availability.feature
+++ b/test/features/resource_availability.feature
@@ -24,6 +24,7 @@ Feature: Re-identification risk governance acknowledgement or Resource visibilit
             | TestOrgEditor |
 
     Scenario: Unauthenticated user should not see a hidden resource when de-identified data is YES and Resource visibility is TRUE and Acknowledgement is NO
+        Given "Unauthenticated" as the persona
         When I go to "/dataset/contains-de-identified-data-yes-visibility-true-acknowledged-no"
         Then I should not see an element with xpath "//a[@title='Hide Resource']"
 
@@ -42,6 +43,7 @@ Feature: Re-identification risk governance acknowledgement or Resource visibilit
             | TestOrgEditor |
 
     Scenario: Unauthenticated user should see a visible resource when de-identified data is NO and Resource visibility is TRUE and Acknowledgement is NO
+        Given "Unauthenticated" as the persona
         When I go to "/dataset/contains-de-identified-data-no-visibility-true-acknowledgment-no"
         And I press the element with xpath "//a[@title='Show Resource']"
         Then I should not see an element with xpath "//th[contains(text(), 'Resource visible')]"
@@ -61,9 +63,9 @@ Feature: Re-identification risk governance acknowledgement or Resource visibilit
             | TestOrgEditor |
 
     Scenario: Unauthenticated user should not see a hidden visible resource when de-identified data is NO and Resource visibility is FALSE and Acknowledgement is NO
+        Given "Unauthenticated" as the persona
         When I go to "/dataset/contains-de-identified-data-no-visibility-false-acknowledgment-no"
         Then I should not see an element with xpath "//a[@title='Hide Resource']"
-
 
     Scenario Outline: Organisation users should see a visible resource when de-identified data is YES and Resource visibility is TRUE and Acknowledgement is YES
         Given "<User>" as the persona
@@ -79,11 +81,11 @@ Feature: Re-identification risk governance acknowledgement or Resource visibilit
             | TestOrgEditor |
 
     Scenario: Unauthenticated user should see a visible resource when de-identified data is YES and Resource visibility is TRUE and Acknowledgement is YES
+        Given "Unauthenticated" as the persona
         When I go to "/dataset/contains-de-identified-data-yes-visibility-true-acknowledgment-yes"
         And I press the element with xpath "//a[@title='Show Resource']"
         Then I should not see an element with xpath "//th[contains(text(), 'Resource visible')]"
         And I should not see an element with xpath "//th[contains(text(), 'Re-identification risk governance completed?')]"
-
 
     Scenario Outline: Create resource and verify default values are set correct for resource visibility
         Given "<User>" as the persona

--- a/test/features/resource_freshness.feature
+++ b/test/features/resource_freshness.feature
@@ -13,7 +13,6 @@ Feature: Resource freshness
             | TestOrgAdmin  |
             | TestOrgEditor |
 
-
     Scenario Outline: An editor, admin or sysadmin user, when I go to the dataset new page and select 'monthly' update frequency, then the text 'Next update due' should be visible
         Given "<User>" as the persona
         When I log in
@@ -26,8 +25,6 @@ Feature: Resource freshness
             | SysAdmin      |
             | TestOrgAdmin  |
             | TestOrgEditor |
-
-
 
     Scenario Outline: An editor, admin or sysadmin user, when I go to the edit dataset page, the text 'Next update due' should be visible
         Given "<User>" as the persona

--- a/test/features/schema_metadata.feature
+++ b/test/features/schema_metadata.feature
@@ -24,8 +24,7 @@ Feature: SchemaMetadata
         And I should see "Description: Missing value"
 
     Scenario: When viewing the HTML source code of a dataset page, the structured data script is visible
-        Given "SysAdmin" as the persona
-        When I log in
+        Given "Unauthenticated" as the persona
         When I go to "/dataset/warandpeace"
         Then I should see an element with xpath "//link[@type='application/ld+json']"
 

--- a/test/features/schema_metadata.feature
+++ b/test/features/schema_metadata.feature
@@ -1,7 +1,6 @@
 @schema_metadata
 Feature: SchemaMetadata
 
-
     Scenario: When a go to the dataset new page, the field field-author_email should not be visible
         Given "SysAdmin" as the persona
         When I log in
@@ -23,6 +22,7 @@ Feature: SchemaMetadata
         Then I should see "Name: Missing value"
         And I should see "Description: Missing value"
 
+    @unauthenticated
     Scenario: When viewing the HTML source code of a dataset page, the structured data script is visible
         Given "Unauthenticated" as the persona
         When I go to "/dataset/warandpeace"
@@ -43,7 +43,6 @@ Feature: SchemaMetadata
             | SysAdmin      |
             | TestOrgAdmin  |
             | TestOrgEditor |
-
 
     Scenario Outline: Edit existing dataset, field de_identified_data value should be NO
         Given "<User>" as the persona
@@ -76,6 +75,7 @@ Feature: SchemaMetadata
             | TestOrgAdmin  |
             | TestOrgEditor |
 
+    @unauthenticated
     Scenario: Non logged-in user should not see de_identified_data value.
         Given "Unauthenticated" as the persona
         When I go to "/dataset/warandpeace"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -213,10 +213,15 @@ def create_dataset(context, license, file_format, file):
     """.format(license=license, file=file, file_format=file_format))
 
 
-# The default behaving step does not convert base64 emails
-# Modified the default step to decode the payload from base64
 @step(u'I should receive a base64 email at "{address}" containing "{text}"')
 def should_receive_base64_email_containing_text(context, address, text):
+    should_receive_base64_email_containing_texts(context, address, text, None)
+
+
+@step(u'I should receive a base64 email at "{address}" containing both "{text}" and "{text2}"')
+def should_receive_base64_email_containing_texts(context, address, text, text2):
+    # The default behaving step does not convert base64 emails
+    # Modified the default step to decode the payload from base64
     def filter_contents(mail):
         mail = email.message_from_string(mail)
         payload = mail.get_payload()
@@ -226,7 +231,7 @@ def should_receive_base64_email_containing_text(context, address, text):
             payload_bytes += b'='  # do fix the padding error issue
         decoded_payload = payload_bytes.decode('base64')
         print('decoded_payload: ', decoded_payload)
-        return text in decoded_payload
+        return text in decoded_payload and (not text2 or text2 in decoded_payload)
 
     assert context.mail.user_messages(address, filter_contents)
 

--- a/test/features/user_creation.feature
+++ b/test/features/user_creation.feature
@@ -9,7 +9,6 @@ Feature: User creation
         Then I fill in "ckanext.data_qld.excluded_display_name_words" with "gov"
         And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
 
-
     Scenario: SysAdmin create a new user to the site.
         Given "SysAdmin" as the persona
         When I log in
@@ -23,9 +22,7 @@ Feature: User creation
         Then I should not see "The username cannot contain the word 'publisher'. Please enter another username."
         Then I should not see "The displayed name cannot contain certain words such as 'publisher', 'QLD Government' or similar. Please enter another display name."
 
-
     Scenario: Non logged-in user register to the site.
-        Given "Unauthenticated" as the persona
         When I go to register page
         Then I should see an element with xpath "//input[@name='fullname']"
         And I should see "Displayed name"

--- a/test/features/users.feature
+++ b/test/features/users.feature
@@ -20,11 +20,12 @@ Feature: User APIs
         Then I should see an element with xpath "//body//div[contains(string(), 'Internal server error')]"
         And I should not see an element with xpath "//*[contains(string(), '"name": "admin"')]"
 
+    @unauthenticated
     Scenario: User autocomplete is not accessible anonymously
+        Given "Unauthenticated" as the persona
         When I search the autocomplete API for user "admin"
         Then I should see an element with xpath "//body//div[contains(string(), 'Internal server error')]"
         And I should not see an element with xpath "//*[contains(string(), '"name": "admin"')]"
-
 
     Scenario Outline: User list is accessible to admins
         Given "<Persona>" as the persona
@@ -44,10 +45,11 @@ Feature: User APIs
         And I go to the user list API
         Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
 
+    @unauthenticated
     Scenario: User list is not accessible anonymously
+        Given "Unauthenticated" as the persona
         When I go to the user list API
         Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'requires an authenticated user')]"
-
 
     Scenario Outline: User detail is accessible to admins
         Given "<Persona>" as the persona
@@ -73,10 +75,11 @@ Feature: User APIs
         And I go to the "admin" user API
         Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
 
+    @unauthenticated
     Scenario: User detail is not accessible anonymously
+        Given "Unauthenticated" as the persona
         When I go to the "editor" user API
         Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'requires an authenticated user')]"
-
 
     Scenario Outline: User profile page is accessible to admins
         Given "<Persona>" as the persona
@@ -102,10 +105,11 @@ Feature: User APIs
         And I go to the "admin" profile page
         Then I should see an element with xpath "//*[contains(string(), 'Not authorised to see this page')]"
 
+    @unauthenticated
     Scenario: User profile page is not accessible anonymously
+        Given "Unauthenticated" as the persona
         When I go to the "editor" profile page
         Then I should see an element with xpath "//*[contains(string(), 'Not authorised to see this page')]"
-
 
     Scenario: Dashboard page is accessible to non-admins
         Given "Publisher" as the persona
@@ -113,7 +117,7 @@ Feature: User APIs
         And I go to the dashboard
         Then I should see an element with xpath "//h2[contains(string(), 'News feed')]"
 
-
+    @email
     Scenario: As a registered user, when I have locked my account with too many failed logins, I can reset my password to unlock it
         Given "Walker" as the persona
         When I lock my account
@@ -132,7 +136,6 @@ Feature: User APIs
         And I fill in "password2" with "$password"
         And I press the element with xpath "//button[@class='btn btn-primary']"
         Then I log in
-
 
     Scenario: Register user password must be 10 characters or longer and contain number, lowercase, capital, and symbol
         When I go to register page


### PR DESCRIPTION
- Use fixed CKAN core version in tests
- Update ckanext-qgov test version
- Reduce dependency on in-browser test setup
- Point unnecessary third-party domains at localhost during tests for faster resolution