### PR TITLE
[DC-31529] ignore 'reorder' APIs when validating mandatory fields

### DIFF
--- a/ckanext/data_qld/helpers.py
+++ b/ckanext/data_qld/helpers.py
@@ -153,7 +153,11 @@ def is_delete_request():
 
 
 def is_api_request():
-    return get_request_action() == 'action' or '/action/' in get_request_path()
+    action = get_request_action()
+    path = get_request_path()
+    return (action == 'action' or '/action/' in path) \
+        and '_reorder' not in action \
+        and '_reorder' not in path
 
 
 def get_gtm_code():

--- a/ckanext/data_qld/helpers.py
+++ b/ckanext/data_qld/helpers.py
@@ -153,11 +153,11 @@ def is_delete_request():
 
 
 def is_api_request():
-    action = get_request_action()
-    path = get_request_path()
-    return (action == 'action' or '/action/' in path) \
-        and '_reorder' not in action \
-        and '_reorder' not in path
+    return get_request_action() == 'action' or '/action/' in get_request_path()
+
+
+def is_update_api_request():
+    return is_api_request() and get_request_path().endswith(('_update', '_patch'))
 
 
 def get_gtm_code():

--- a/ckanext/data_qld/resource_freshness/validation.py
+++ b/ckanext/data_qld/resource_freshness/validation.py
@@ -55,7 +55,7 @@ def validate_next_update_due(keys, flattened_data, errors, context):
                 errors[keys].append(_("Valid date in the future is required"))
         elif data_qld_helpers.is_api_request() or not current_next_update_due:
             flattened_data[keys] = resource_freshness_helpers.recalculate_next_update_due_date(flattened_data, update_frequency, errors, context)
-        else:
+        elif data_qld_helpers.get_request():  # ignore background jobs
             errors[keys].append(_('Missing value'))
             raise StopOnError
     else:

--- a/ckanext/data_qld/resource_freshness/validation.py
+++ b/ckanext/data_qld/resource_freshness/validation.py
@@ -53,7 +53,7 @@ def validate_next_update_due(keys, flattened_data, errors, context):
             today = dt.datetime.now(h.get_display_timezone())
             if next_update_due.date() <= today.date():
                 errors[keys].append(_("Valid date in the future is required"))
-        elif data_qld_helpers.is_api_request() or not current_next_update_due:
+        elif data_qld_helpers.is_update_api_request() or not current_next_update_due:
             flattened_data[keys] = resource_freshness_helpers.recalculate_next_update_due_date(flattened_data, update_frequency, errors, context)
         elif data_qld_helpers.get_request():  # ignore background jobs
             errors[keys].append(_('Missing value'))
@@ -84,7 +84,7 @@ def validate_nature_of_change_data(keys, flattened_data, errors, context):
         # Only validate the current resource being updated unless its coming from the API
         # The resource_data_updated value is set in  the 'before_update' IResource interface method 'check_resource_data'
         resource_data_updated = context.get('resource_data_updated', {})
-        api_request = data_qld_helpers.is_api_request()
+        api_request = data_qld_helpers.is_update_api_request()
         if api_request or resource_data_updated and resource_data_updated.get('id') == resource.get('id'):
             if api_request or resource_data_updated.get('data_updated', False) is True:
                 # Resource data has been updated or the call is from the API so the nature_of_change validation is required


### PR DESCRIPTION
- the 'reorder' APIs don't change any actual values, so they shouldn't require a reason to be specified