### PR TITLE
DC-31541 Don't overwrite nature_of_change in background jobs

### DIFF
--- a/ckanext/data_qld/helpers.py
+++ b/ckanext/data_qld/helpers.py
@@ -21,6 +21,9 @@ def get_user():
 
 
 def user_has_admin_access(include_editor_access):
+    # background jobs should be treated as admins
+    if not get_request():
+        return True
     user = get_user()
     # If user is "None" - they are not logged in.
     if user is None:

--- a/ckanext/data_qld/plugin.py
+++ b/ckanext/data_qld/plugin.py
@@ -181,7 +181,7 @@ class DataQldPlugin(MixinPlugin, plugins.SingletonPlugin):
         if context.get('ignore_auth', False) is not True:
             resource_visibility_helpers.process_resources(data_dict, helpers.get_user())
             de_identified_data_helpers.process_de_identified_data_dict(data_dict, helpers.get_user())
-        resource_freshness_helpers.process_next_update_due(data_dict)
+            resource_freshness_helpers.process_next_update_due(data_dict)
 
     def after_search(self, search_results, search_params):
         for data_dict in search_results.get('results', []):

--- a/test/features/resource_freshness.feature
+++ b/test/features/resource_freshness.feature
@@ -26,16 +26,16 @@ Feature: Resource freshness
             | TestOrgAdmin  |
             | TestOrgEditor |
 
-    Scenario Outline: An editor, admin or sysadmin user, when I go to the edit dataset page, the text 'Next update due' should be visible
+    Scenario Outline: As a user with editing privileges, when I set a 'monthly' update frequently, I should still be able to update the dataset via the API
         Given "<User>" as the persona
         When I log in
-        And I go to "/dataset/edit/warandpeace"
+        And I go to "/dataset/edit/test-dataset"
         And I select "monthly" from "update_frequency"
         Then I should see "Next update due"
         When I fill in "next_update_due" with "01/01/1970"
         And I press the element with xpath "//form[contains(@class, 'dataset-form')]//button[contains(@class, 'btn-primary')]"
         And I wait for 3 seconds
-        Then I should be able to patch dataset "warandpeace" via the API
+        Then I should be able to patch dataset "test-dataset" via the API
 
         Examples: Users
             | User          |

--- a/test/features/resource_freshness.feature
+++ b/test/features/resource_freshness.feature
@@ -32,6 +32,10 @@ Feature: Resource freshness
         And I go to "/dataset/edit/warandpeace"
         And I select "monthly" from "update_frequency"
         Then I should see "Next update due"
+        When I fill in "next_update_due" with "01/01/1970"
+        And I press the element with xpath "//form[contains(@class, 'resource-form')]//button[contains(@class, 'btn-primary')]"
+        And I wait for 3 seconds
+        Then I should be able to patch dataset "warandpeace" via the API
 
         Examples: Users
             | User          |

--- a/test/features/resource_freshness.feature
+++ b/test/features/resource_freshness.feature
@@ -33,7 +33,7 @@ Feature: Resource freshness
         And I select "monthly" from "update_frequency"
         Then I should see "Next update due"
         When I fill in "next_update_due" with "01/01/1970"
-        And I press the element with xpath "//form[contains(@class, 'resource-form')]//button[contains(@class, 'btn-primary')]"
+        And I press the element with xpath "//form[contains(@class, 'dataset-form')]//button[contains(@class, 'btn-primary')]"
         And I wait for 3 seconds
         Then I should be able to patch dataset "warandpeace" via the API
 

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -177,6 +177,14 @@ def test_download_element(context, expression):
     assert requests.get(url, cookies=context.browser.cookies.all()).status_code == 200
 
 
+@step(u'I should be able to patch dataset "{package_id}" via the API')
+def test_package_patch(context, package_id):
+    url = context.base_url + '/api/action/package_patch'
+    response = requests.post(url, data={'id': package_id}, cookies=context.browser.cookies.all())
+    assert response.status_code == 200
+    assert '"success": true' in response.text
+
+
 @step(u'I create a dataset with title "{title}"')
 def create_dataset_titled(context, title):
     context.execute_steps(u"""

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -4,12 +4,9 @@ from behaving.mail.steps import *  # noqa: F401, F403
 from behaving.web.steps import *  # noqa: F401, F403
 from behaving.web.steps.url import when_i_visit_url
 import email
-import logging
 import quopri
 import requests
 import uuid
-
-log = logging.getLogger(__name__)
 
 
 @step(u'I get the current URL')
@@ -184,7 +181,7 @@ def test_download_element(context, expression):
 def test_package_patch(context, package_id):
     url = context.base_url + '/api/action/package_patch'
     response = requests.post(url, data={'id': package_id}, cookies=context.browser.cookies.all())
-    log.info("Response from endpoint %s is: %s", url, response)
+    print("Response from endpoint {} is: {}".format(url, response))
     assert response.status_code == 200
     assert '"success": true' in response.text
 

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -180,7 +180,7 @@ def test_download_element(context, expression):
 @step(u'I should be able to patch dataset "{package_id}" via the API')
 def test_package_patch(context, package_id):
     url = context.base_url + '/api/action/package_patch'
-    response = requests.post(url, data={'id': package_id}, cookies=context.browser.cookies.all())
+    response = requests.post(url, data='{"id": "%s"}' % package_id, cookies=context.browser.cookies.all())
     print("Response from endpoint {} is: {}".format(url, response))
     assert response.status_code == 200
     assert '"success": true' in response.text

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -4,9 +4,12 @@ from behaving.mail.steps import *  # noqa: F401, F403
 from behaving.web.steps import *  # noqa: F401, F403
 from behaving.web.steps.url import when_i_visit_url
 import email
+import logging
 import quopri
 import requests
 import uuid
+
+log = logging.getLogger(__name__)
 
 
 @step(u'I get the current URL')
@@ -181,6 +184,7 @@ def test_download_element(context, expression):
 def test_package_patch(context, package_id):
     url = context.base_url + '/api/action/package_patch'
     response = requests.post(url, data={'id': package_id}, cookies=context.browser.cookies.all())
+    log.info("Response from endpoint %s is: %s", url, response)
     assert response.status_code == 200
     assert '"success": true' in response.text
 

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -180,7 +180,7 @@ def test_download_element(context, expression):
 
 @step(u'I should be able to patch dataset "{package_id}" via the API')
 def test_package_patch(context, package_id):
-    url = context.base_url + '/api/action/package_patch'
+    url = context.base_url + 'api/action/package_patch'
     data = json.dumps({'id': package_id})
     response = requests.post(url, data=data, cookies=context.browser.cookies.all())
     print("Response from endpoint {} is: {}, {}".format(url, response, response.text))

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -4,7 +4,6 @@ from behaving.mail.steps import *  # noqa: F401, F403
 from behaving.web.steps import *  # noqa: F401, F403
 from behaving.web.steps.url import when_i_visit_url
 import email
-import json
 import quopri
 import requests
 import uuid
@@ -181,8 +180,7 @@ def test_download_element(context, expression):
 @step(u'I should be able to patch dataset "{package_id}" via the API')
 def test_package_patch(context, package_id):
     url = context.base_url + 'api/action/package_patch'
-    data = json.dumps({'id': package_id})
-    response = requests.post(url, data=data, cookies=context.browser.cookies.all())
+    response = requests.post(url, json={'id': package_id}, cookies=context.browser.cookies.all())
     print("Response from endpoint {} is: {}, {}".format(url, response, response.text))
     assert response.status_code == 200
     assert '"success": true' in response.text

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -4,6 +4,7 @@ from behaving.mail.steps import *  # noqa: F401, F403
 from behaving.web.steps import *  # noqa: F401, F403
 from behaving.web.steps.url import when_i_visit_url
 import email
+import json
 import quopri
 import requests
 import uuid
@@ -180,8 +181,9 @@ def test_download_element(context, expression):
 @step(u'I should be able to patch dataset "{package_id}" via the API')
 def test_package_patch(context, package_id):
     url = context.base_url + '/api/action/package_patch'
-    response = requests.post(url, data='{"id": "%s"}' % package_id, cookies=context.browser.cookies.all())
-    print("Response from endpoint {} is: {}".format(url, response))
+    data = json.dumps({'id': package_id})
+    response = requests.post(url, data=data, cookies=context.browser.cookies.all())
+    print("Response from endpoint {} is: {}, {}".format(url, response, response.text))
     assert response.status_code == 200
     assert '"success": true' in response.text
 


### PR DESCRIPTION
Background jobs have already been fixed so that they don't fail validation, but they also need to be adjusted so that they don't overwrite nature_of_change with a blank.