### PR TITLE
[QOL-8988] add our custom robots.txt file

### DIFF
--- a/ckanext/data_qld/blueprints.py
+++ b/ckanext/data_qld/blueprints.py
@@ -7,11 +7,6 @@ from ckantoolkit import render
 from constants import DATAREQUESTS_MAIN_PATH, SCHEMA_MAIN_PATH
 from controller_functions import open_datarequest, show_schema
 
-
-def header_snippet():
-    return render('header.html')
-
-
 blueprint = Blueprint(
     u'data_qld',
     __name__
@@ -23,4 +18,5 @@ blueprint.add_url_rule(
 blueprint.add_url_rule(
     u'/dataset/<dataset_id>resource/<resource_id>/{}/show'.format(SCHEMA_MAIN_PATH),
     view_func=show_schema)
-blueprint.add_url_rule(u'/header.html', view_func=header_snippet)
+blueprint.add_url_rule(u'/header.html', 'header', view_func=lambda: render('header.html'))
+blueprint.add_url_rule(u'/robots.txt', 'robots', view_func=lambda: render('robots.txt'))

--- a/ckanext/data_qld/templates/robots.txt
+++ b/ckanext/data_qld/templates/robots.txt
@@ -1,5 +1,3 @@
-{% ckan_extends %}
-
 {% block all_user_agents %}
 {% if h.is_prod() %}
 {% raw %}

--- a/test/features/data_qld_theme.feature
+++ b/test/features/data_qld_theme.feature
@@ -102,3 +102,10 @@ Feature: Theme customisations
         And I should see an element with xpath "//a[@href='/user/register' and contains(string(), 'Register')]"
         And I should see an element with xpath "//a[@href='/datarequest' and contains(string(), 'Request data')]"
         And I should not see "not found"
+
+    @unauthenticated
+    Scenario: When I go to the robots file, I can see a custom disallow block
+        Given "Unauthenticated" as the persona
+        When I go to "/robots.txt"
+        Then I should see "Disallow: /"
+        And I should not see "Allow:"


### PR DESCRIPTION
- CKAN 2.9 reverted to serving it from the 'public' directory, but we want Jinja syntax,
so instead we add a Flask blueprint rule to render it