### PR TITLE
fix fatal: detected dubious ownership in repository at '/srv/app/src/ckan

### DIFF
--- a/.docker/Dockerfile-template.ckan
+++ b/.docker/Dockerfile-template.ckan
@@ -14,6 +14,7 @@ RUN apk add --no-cache build-base \
 # Install CKAN.
 
 RUN cd $SRC_DIR/ckan \
+    && git config --global --add safe.directory "$SRC_DIR/ckan" \
     && git remote set-url origin 'https://github.com/qld-gov-au/ckan.git' \
     && git fetch \
     && git reset --hard && git clean -f \


### PR DESCRIPTION
To add an exception for this directory, call:

	git config --global --add safe.directory /srv/app/src/ckan

This is on the 2.9 py3 container image at this time.