### PR TITLE
[QOLDEV-312] add support for CKAN 2.10 dashboard routing

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -17,6 +17,9 @@ ahoy pull
 if [ "$CKAN_VERSION" = "2.8" ]; then
     PYTHON_VERSION=py2
     QGOV_CKAN_VERSION=ckan-2.8.8-qgov.5
+elif [ "$CKAN_VERSION" = "2.10" ]; then
+    PYTHON_VERSION=py3
+    QGOV_CKAN_VERSION=ckan-2.10.0
 else
     QGOV_CKAN_VERSION=ckan-2.9.5-qgov.8
     if [ "$CKAN_VERSION" = "2.9-py2" ]; then

--- a/.docker/ckan.ini
+++ b/.docker/ckan.ini
@@ -110,7 +110,7 @@ ckan.plugins =
     dcat qa archiver report qgovext
     ytp_comments datarequests xloader
     csrf_filter
-    ssm_config odi_certificates
+    ssm_config
     data_qld_test
     resource_visibility
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: ["2.10", 2.9, 2.9-py2]
+        ckan-version: [2.9, 2.9-py2]
 
     name: Continuous Integration build on CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest

--- a/ckanext/data_qld/helpers.py
+++ b/ckanext/data_qld/helpers.py
@@ -198,6 +198,15 @@ def is_datarequests_enabled():
     return _is_action_configured('list_datarequests')
 
 
+def dashboard_index_route():
+    if check_ckan_version('2.10'):
+        if _is_action_configured('dashboard_activity_list'):
+            return 'activity.dashboard'
+        else:
+            return 'dashboard.datasets'
+    return 'dashboard.index'
+
+
 def get_all_groups():
     groups = get_action('group_list')(
         data_dict={'include_dataset_count': False, 'all_fields': True})

--- a/ckanext/data_qld/plugin.py
+++ b/ckanext/data_qld/plugin.py
@@ -82,6 +82,7 @@ class DataQldPlugin(MixinPlugin, plugins.SingletonPlugin):
             'get_gtm_container_id': helpers.get_gtm_code,
             'get_year': helpers.get_year,
             'ytp_comments_enabled': helpers.ytp_comments_enabled,
+            'dashboard_index_route': helpers.dashboard_index_route,
             'is_ckan_29': helpers.is_ckan_29,
             'is_datarequests_enabled': helpers.is_datarequests_enabled,
             'get_all_groups': helpers.get_all_groups,

--- a/ckanext/data_qld/templates/header.html
+++ b/ckanext/data_qld/templates/header.html
@@ -25,7 +25,7 @@
         <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
           {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities)
           %}
-          <a href="{{ h.url_for('dashboard.index') }}" title="{{ notifications_tooltip }}">
+          <a href="{{ h.url_for(h.dashboard_index_route()) }}" title="{{ notifications_tooltip }}">
             <i class="fa fa-tachometer" aria-hidden="true"></i>
             <span class="text">{{ _('Dashboard') }}</span>
             <span class="badge">{{ new_activities }}</span>

--- a/ckanext/data_qld/templates/user/dashboard.html
+++ b/ckanext/data_qld/templates/user/dashboard.html
@@ -6,7 +6,7 @@
     {% link_for _('Edit settings'), named_route='user.edit', id=user_dict.get('name', ''), class_='btn btn-default', icon='cog' %}
   </div>
   <ul class="nav nav-tabs">
-    {{ h.build_nav_icon('dashboard.index', _('News feed')) }}
+    {{ h.build_nav_icon(h.dashboard_index_route(), _('News feed')) }}
     {{ h.build_nav_icon('dashboard.datasets', _('My Datasets')) }}
     {{ h.build_nav_icon('dashboard.organizations', _('My Organizations')) }}
     {{ h.build_nav_icon('dashboard.groups', _('My Groups')) }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       - default
 
   solr:
-    image: ckan/ckan-solr-dev:${CKAN_VERSION}
+    image: ckan/ckan-solr:${CKAN_VERSION}
     ports:
       - "8983"
     environment:

--- a/extensions.txt
+++ b/extensions.txt
@@ -11,6 +11,6 @@
 -e git+https://github.com/qld-gov-au/ckanext-ssm-config.git@0.0.2#egg=ckanext-ssm-config
 -e git+https://github.com/qld-gov-au/ckanext-validation.git@v0.0.8-qgov.8#egg=ckanext-validation
 -e git+https://github.com/qld-gov-au/ckanext-xloader.git@0.11.0-qgov.2#egg=ckanext-xloader
--e git+https://github.com/qld-gov-au/ckanext-ytp-comments.git@2.5.0-qgov.9#egg=ckanext-ytp-comments
+-e git+https://github.com/qld-gov-au/ckanext-ytp-comments.git@2.5.0-qgov.10#egg=ckanext-ytp-comments
 -e git+https://github.com/qld-gov-au/ckanext-resource-visibility.git@develop#egg=ckanext-resource-visibility
 -e git+https://github.com/qld-gov-au/ckanext-validation-schema-generator.git@develop#egg=ckanext-validation-schema-generator

--- a/extensions.txt
+++ b/extensions.txt
@@ -3,7 +3,6 @@
 -e git+https://github.com/qld-gov-au/ckanext-archiver.git@2.1.1-qgov.14#egg=ckanext-archiver
 -e git+https://github.com/qld-gov-au/ckanext-csrf-filter.git@1.1.6#egg=ckanext-csrf-filter
 -e git+https://github.com/qld-gov-au/ckanext-datarequests.git@2.2.1-qgov.5#egg=ckanext-datarequests
--e git+https://github.com/qld-gov-au/ckanext-odi-certificates.git@1.0.1#egg=ckanext-odi-certificates
 -e git+https://github.com/qld-gov-au/ckanext-qa.git@2.0.3-qgov.7#egg=ckanext-qa
 -e git+https://github.com/qld-gov-au/ckanext-qgov.git@5.0.7#egg=ckanext-qgov
 -e git+https://github.com/qld-gov-au/ckanext-report.git@0.3.1-qgov.2#egg=ckanext-report


### PR DESCRIPTION
- News feeds have now moved to ckanext-activity, which is provided but not enabled out of the box. With the extension enabled, the route is 'activity.dashboard'; without it, the appropriate route is the dataset page, 'dashboard.datasets'