### PR TITLE
QOLSVC-2447 don't truncate resource names

### DIFF
--- a/ckanext/data_qld/templates/package/read.html
+++ b/ckanext/data_qld/templates/package/read.html
@@ -14,3 +14,12 @@
 
 <meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="index" />
 {% endblock %}
+
+{% block breadcrumb_content %}
+    {% set index_route_name = 'organization.index' %}
+    {% set org_route_name = 'organization.read' %}
+    <li>{% link_for _('Organizations'), named_route=index_route_name %}</li>
+    <li>{% link_for pkg.organization.title, named_route=org_route_name, id=pkg.organization.name %}</li>
+    {% set dataset_read_route = 'dataset.read' %}
+    <li class="active"><a href="{{ h.url_for(dataset_read_route, id=pkg.name) }}">{{ pkg.title }}</a></li>
+{% endblock %}

--- a/ckanext/data_qld/templates/package/resource_read.html
+++ b/ckanext/data_qld/templates/package/resource_read.html
@@ -20,6 +20,16 @@
 
 {% block subtitle %}{{ h.resource_display_name(res) }} - {{ h.dataset_display_name(c.package) }}{% endblock %}
 
+{% block breadcrumb_content %}
+    {% set index_route_name = 'organization.index' %}
+    {% set org_route_name = 'organization.read' %}
+    <li>{% link_for _('Organizations'), named_route=index_route_name %}</li>
+    <li>{% link_for pkg.organization.title, named_route=org_route_name, id=pkg.organization.name %}</li>
+    {% set dataset_read_route = 'dataset.read' %}
+    <li class="active"><a href="{{ h.url_for(dataset_read_route, id=pkg.name) }}">{{ pkg.title }}</a></li>
+    <li class="active"><a href="">{{ h.resource_display_name(res) }}</a></li>
+{% endblock %}
+
 {% block pre_primary %}
 {% endblock %}
 

--- a/ckanext/data_qld/templates/scheming/package/read.html
+++ b/ckanext/data_qld/templates/scheming/package/read.html
@@ -1,14 +1,5 @@
 {% ckan_extends %}
 
-{% block breadcrumb_content %}
-    {% set index_route_name = 'organization.index' %}
-    {% set org_route_name = 'organization.read' %}
-    <li>{% link_for _('Organizations'), named_route=index_route_name %}</li>
-    <li>{% link_for pkg.organization.title, named_route=org_route_name, id=pkg.organization.name %}</li>
-    {% set dataset_read_route = 'dataset.read' %}
-    <li class="active"><a href="{{ h.url_for(dataset_read_route, id=pkg.name) }}">{{ pkg.title }}</a></li>
-{% endblock %}
-
 {% block package_notes %}
     <section>
       {{ h.qa_openness_stars_dataset_html(pkg) }}

--- a/ckanext/data_qld/test_plugin.py
+++ b/ckanext/data_qld/test_plugin.py
@@ -12,7 +12,7 @@ class DataQldTestPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IActions)
 
     def update_config(self, config):
-        assert tk.asbool(tk.config.get("ckanext.data_qld.allow_bdd_test_plugin")),\
+        assert tk.asbool(tk.config.get("ckanext.data_qld.allow_bdd_test_plugin")), \
             'BDD test plugin is not allowed'
 
     # IActions


### PR DESCRIPTION
Truncation is already disabled on dataset pages, but we also need to disable it on resource pages.