### PR TITLE
[QOLDEV-613] drop duplicate definition of 'url_type' input field

### DIFF
--- a/ckanext/data_qld/templates/scheming/form_snippets/upload.html
+++ b/ckanext/data_qld/templates/scheming/form_snippets/upload.html
@@ -11,8 +11,6 @@
     {% endif %}
 {% endif %}
 
-{{ form.hidden('url_type', data.url_type) }}
-
 {%- set is_upload = (data.url_type == 'upload') -%}
 {{ form.image_upload(
     data,


### PR DESCRIPTION
- The duplicate results in the server getting two values and squashing them into a list, which is bad