### PR TITLE
Develop to master - drop duplicate 'url_type' field

### DIFF
--- a/ckanext/data_qld/templates/base.html
+++ b/ckanext/data_qld/templates/base.html
@@ -5,6 +5,9 @@
 <meta name="DCTERMS.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=The State of Queensland; jurisdiction=Queensland" />
 <meta name="DCTERMS.jurisdiction" scheme="AGLSTERMS.AglsJuri" content="Queensland" />
 <meta name="DCTERMS.type" scheme="DCTERMS.DCMIType" content="Text" />
+{% if not h.is_prod() %}
+<meta name="robots" content="noindex" />
+{% endif %}
 {% endblock %}
 
 {% block custom_styles %}

--- a/ckanext/data_qld/templates/scheming/form_snippets/upload.html
+++ b/ckanext/data_qld/templates/scheming/form_snippets/upload.html
@@ -11,8 +11,6 @@
     {% endif %}
 {% endif %}
 
-{{ form.hidden('url_type', data.url_type) }}
-
 {%- set is_upload = (data.url_type == 'upload') -%}
 {{ form.image_upload(
     data,


### PR DESCRIPTION
Our template is unnecessarily adding a copy of the `url_type` field, which creates problems on CKAN 2.10.