### PR TITLE
[QOLDEV-640] apply link styling to header buttons with the 'btn-link' class

### DIFF
--- a/ckanext/data_qld/fanstatic/data_qld.css
+++ b/ckanext/data_qld/fanstatic/data_qld.css
@@ -304,7 +304,8 @@ div.account-masthead .account ul.unstyled li {
   border: none;
 }
 
-div.account-masthead .account ul.unstyled li a {
+div.account-masthead .account ul.unstyled li a,
+div.account-masthead .account ul.unstyled li .btn-link {
   color: #ffffff;
   text-decoration: none;
   line-height: 1rem;
@@ -327,7 +328,9 @@ div.account-masthead .account ul.unstyled li a {
 }
 
 div.account-masthead .account ul.unstyled li a:hover,
-div.account-masthead .account ul.unstyled li a:focus {
+div.account-masthead .account ul.unstyled li a:focus,
+div.account-masthead .account ul.unstyled li .btn-link:hover,
+div.account-masthead .account ul.unstyled li .btn-link:focus {
   color: #ffffff;
   background-color: #007eb1;
 }


### PR DESCRIPTION
CKAN core developers are looking at changing the logout link into a button (see https://github.com/ckan/ckan/pull/7892), so we should adjust our styling to include that.