### PR TITLE
[QOLSVC-3914] reuse parent header block for not-logged-in content

### DIFF
--- a/ckanext/data_qld/templates/header.html
+++ b/ckanext/data_qld/templates/header.html
@@ -46,11 +46,7 @@
     {% else %}
     <nav class="account not-authed">
       <ul class="unstyled">
-        {% block header_account_notlogged %}
-        <li>{% link_for _('Log in'), named_route='user.login' %}</li>
-        {% if h.check_access('user_create') %}
-        <li>{% link_for _('Register'), named_route='user.register', class_='sub' %}</li>
-        {% endif %} {% endblock %}
+        {% block header_account_notlogged %}{{ super() }}{% endblock %}
         {% if h.is_datarequests_enabled() %}
         <li><a href="{{ h.url_for('datarequest.index') }}">Request data</a></li>
         {% endif %}


### PR DESCRIPTION
- Replacing the block entirely makes us less forward-compatible