### PR TITLE
[QOLDEV-1011] drop Pylons 'c' object from data request handling

### DIFF
--- a/ckanext/data_qld/controller_functions.py
+++ b/ckanext/data_qld/controller_functions.py
@@ -3,7 +3,7 @@
 import logging
 import json
 
-from ckantoolkit import _, abort, c, check_access, g, get_action, \
+from ckantoolkit import _, abort, check_access, g, get_action, \
     redirect_to, NotAuthorized, ObjectNotFound, url_for, \
     ValidationError, render
 
@@ -38,17 +38,17 @@ def open_datarequest(id):
     context = _get_context()
 
     # Basic initialization
-    c.datarequest = {}
+    datarequest = {}
     try:
         check_access(OPEN_DATAREQUEST, context, data_dict)
-        c.datarequest = get_action(SHOW_DATAREQUEST)(context, data_dict)
+        datarequest = get_action(SHOW_DATAREQUEST)(context, data_dict)
 
-        if c.datarequest.get('closed', False) is False:
+        if datarequest.get('closed', False) is False:
             return abort(403, _('This data request is already open'))
         else:
             data_dict = {}
             data_dict['id'] = id
-            data_dict['organization_id'] = c.datarequest.get('organization_id')
+            data_dict['organization_id'] = datarequest.get('organization_id')
 
             get_action(OPEN_DATAREQUEST)(context, data_dict)
             return redirect_to(url_for('datarequest.show', id=data_dict['id']))

--- a/ckanext/data_qld/helpers.py
+++ b/ckanext/data_qld/helpers.py
@@ -6,7 +6,7 @@ from six import text_type
 
 from ckan import model
 from ckan.lib import uploader
-from ckantoolkit import _, c, g, h, abort, asbool, check_ckan_version, \
+from ckantoolkit import _, g, h, abort, asbool, check_ckan_version, \
     config, get_action, get_endpoint, ObjectNotFound, render, request, \
     aslist
 
@@ -205,16 +205,6 @@ def dashboard_index_route():
         else:
             return 'dashboard.datasets'
     return 'dashboard.index'
-
-
-def get_all_groups():
-    groups = get_action('group_list')(
-        data_dict={'include_dataset_count': False, 'all_fields': True})
-    pkg_group_ids = set(group['id'] for group
-                        in c.pkg_dict.get('groups', []))
-    return [[group['id'], group['display_name']]
-            for group in groups if
-            group['id'] not in pkg_group_ids]
 
 
 def get_comment_notification_recipients_enabled():

--- a/ckanext/data_qld/plugin.py
+++ b/ckanext/data_qld/plugin.py
@@ -90,7 +90,6 @@ class DataQldPlugin(plugins.SingletonPlugin):
             'ytp_comments_enabled': helpers.ytp_comments_enabled,
             'dashboard_index_route': helpers.dashboard_index_route,
             'is_datarequests_enabled': helpers.is_datarequests_enabled,
-            'get_all_groups': helpers.get_all_groups,
             'is_request_for_resource': helpers.is_request_for_resource,
             'set_background_image_class': helpers.set_background_image_class,
             'set_external_resources': helpers.set_external_resources,

--- a/ckanext/data_qld/templates/datarequests/close.html
+++ b/ckanext/data_qld/templates/datarequests/close.html
@@ -1,4 +1,7 @@
 {% ckan_extends %}
+{#
+Handle either old Pylons-style global variables, or newer template parameters.
+#}
 {% set datasets = datasets or c.datasets %}
 {% set datarequest = datarequest or c.datarequest %}
 {% set errors = errors or c.errors %}

--- a/ckanext/data_qld/templates/datarequests/close.html
+++ b/ckanext/data_qld/templates/datarequests/close.html
@@ -1,16 +1,20 @@
 {% ckan_extends %}
+{% set datasets = datasets or c.datasets %}
+{% set datarequest = datarequest or c.datarequest %}
+{% set errors = errors or c.errors %}
+{% set errors_summary = errors_summary or c.errors_summary %}
 
 {% block subtitle %}{{ _('Close data request') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Data requests'), named_route='datarequest.index' %}</li>
-  <li>{% link_for c.datarequest.get('title')|truncate(30), named_route='datarequest.show', id=c.datarequest.get('id') %}</li>
+  <li>{% link_for datarequest.get('title')|truncate(30), named_route='datarequest.show', id=datarequest.get('id') %}</li>
   <li class="active"><a href="">{{ _('Close data request') }}</a></li>
 {% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="{% block page_heading_class %}page-heading{% endblock %}">{% block page_heading %}{{ _('Close data request') }}{% endblock %}</h1>
-  {% snippet "datarequests/snippets/close_datarequest_form.html", datarequest=c.datarequest, datasets=c.datasets, errors=c.errors, errors_summary=c.errors_summary  %}
+  {% snippet "datarequests/snippets/close_datarequest_form.html", datarequest=datarequest, datasets=datasets, errors=errors, errors_summary=errors_summary  %}
 {% endblock %}
 
 {% block page_header %}{% endblock %}

--- a/ckanext/data_qld/templates/datarequests/comment.html
+++ b/ckanext/data_qld/templates/datarequests/comment.html
@@ -8,6 +8,9 @@
 
 
 {% block primary_content_inner %}
+  {#
+  Handle either old Pylons-style global variables, or newer template parameters.
+  #}
   {% set datarequest = datarequest or c.datarequest %}
   {% set userobj = userobj or c.userobj %}
   {% snippet "package/comment_list.html", content_type='datarequest', pkg_id=datarequest.id, pkg_name=datarequest.id, userobj=userobj %}

--- a/ckanext/data_qld/templates/datarequests/comment.html
+++ b/ckanext/data_qld/templates/datarequests/comment.html
@@ -8,7 +8,8 @@
 
 
 {% block primary_content_inner %}
-
-  {% snippet "package/comment_list.html", content_type='datarequest', pkg_id=c.datarequest.id, pkg_name=c.datarequest.id, userobj=c.userobj %}
+  {% set datarequest = datarequest or c.datarequest %}
+  {% set userobj = userobj or c.userobj %}
+  {% snippet "package/comment_list.html", content_type='datarequest', pkg_id=datarequest.id, pkg_name=datarequest.id, userobj=userobj %}
 
 {% endblock %}

--- a/ckanext/data_qld/templates/datarequests/edit.html
+++ b/ckanext/data_qld/templates/datarequests/edit.html
@@ -1,16 +1,20 @@
 {% ckan_extends %}
+{% set datarequest = datarequest or c.datarequest %}
+{% set errors = errors or c.errors %}
+{% set errors_summary = errors_summary or c.errors_summary %}
+{% set original_title = original_title or c.original_title %}
 
 {% block subtitle %}{{ _('Edit data request') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Data requests'), named_route='datarequest.index' %}</li>
-  <li>{% link_for c.original_title|truncate(30), named_route='datarequest.show', id=c.datarequest.get('id') %}</li>
+  <li>{% link_for original_title|truncate(30), named_route='datarequest.show', id=datarequest.get('id') %}</li>
   <li class="active"><a href="">{{ _('Edit data request') }}</a></li>
 {% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="{% block page_heading_class %}page-heading{% endblock %}">{% block page_heading %}{{ _('Edit data request') }}{% endblock %}</h1>
-  {% snippet "datarequests/snippets/edit_datarequest_form.html", data=c.datarequest, errors=c.errors, errors_summary=c.errors_summary, offering=c.offering %}
+  {% snippet "datarequests/snippets/edit_datarequest_form.html", data=datarequest, errors=errors, errors_summary=errors_summary %}
 {% endblock %}
 
 {% block page_header %}{% endblock %}

--- a/ckanext/data_qld/templates/datarequests/edit.html
+++ b/ckanext/data_qld/templates/datarequests/edit.html
@@ -1,4 +1,7 @@
 {% ckan_extends %}
+{#
+Handle either old Pylons-style global variables, or newer template parameters.
+#}
 {% set datarequest = datarequest or c.datarequest %}
 {% set errors = errors or c.errors %}
 {% set errors_summary = errors_summary or c.errors_summary %}

--- a/ckanext/data_qld/templates/datarequests/new.html
+++ b/ckanext/data_qld/templates/datarequests/new.html
@@ -1,4 +1,7 @@
 {% ckan_extends %}
+{#
+Handle either old Pylons-style global variables, or newer template parameters.
+#}
 {% set datarequest = datarequest or c.datarequest %}
 {% set errors = errors or c.errors %}
 {% set errors_summary = errors_summary or c.errors_summary %}

--- a/ckanext/data_qld/templates/datarequests/new.html
+++ b/ckanext/data_qld/templates/datarequests/new.html
@@ -1,4 +1,7 @@
 {% ckan_extends %}
+{% set datarequest = datarequest or c.datarequest %}
+{% set errors = errors or c.errors %}
+{% set errors_summary = errors_summary or c.errors_summary %}
 
 {% block subtitle %}{{ _('Create data request') }}{% endblock %}
 
@@ -9,7 +12,7 @@
 
 {% block primary_content_inner %}
   <h1 class="{% block page_heading_class %}page-heading{% endblock %}">{% block page_heading %}{{ _('Create data request') }}{% endblock %}</h1>
-  {% snippet "datarequests/snippets/new_datarequest_form.html", data=c.datarequest, errors=c.errors, errors_summary=c.errors_summary, offering=c.offering %}
+  {% snippet "datarequests/snippets/new_datarequest_form.html", data=datarequest, errors=errors, errors_summary=errors_summary %}
 {% endblock %}
 
 {% block secondary_content_additional_info %}

--- a/ckanext/data_qld/templates/datarequests/show.html
+++ b/ckanext/data_qld/templates/datarequests/show.html
@@ -1,10 +1,11 @@
 {% ckan_extends %}
+{% set datarequest = datarequest or c.datarequest %}
 
-{% block title %}Data request {{c.datarequest.get('title', '')}}{% endblock %}
+{% block title %}Data request {{datarequest.get('title', '')}}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Data requests'), named_route='datarequest.index' %}</li>
-  <li>{% link_for c.datarequest.get('title'), named_route='datarequest.show', id=datarequest_id %}</li>
+  <li>{% link_for datarequest.get('title'), named_route='datarequest.show', id=datarequest_id %}</li>
 {% endblock %}
 
 {% block content_action %}
@@ -13,11 +14,11 @@
     {% link_for _('Manage'), named_route='datarequest.update', id=datarequest_id, class_='btn btn-default', icon='wrench' %}
   {% endif %}
 
-  {% if h.check_access('close_datarequest', {'id':datarequest_id }) and not c.datarequest.closed %}
+  {% if h.check_access('close_datarequest', {'id':datarequest_id }) and not datarequest.closed %}
     {% link_for _('Close'), named_route='datarequest.close', id=datarequest_id, class_='btn btn-danger', icon='lock' %}
   {% endif %}
 
-  {% if h.check_access('open_datarequest', {'id':datarequest_id }) and c.datarequest.closed %}
+  {% if h.check_access('open_datarequest', {'id':datarequest_id }) and datarequest.closed %}
     {% link_for _('Re-open'), named_route='data_qld.open_datarequest', id=datarequest_id, class_='btn btn-success', icon='unlock' %}
   {% endif %}
 

--- a/ckanext/data_qld/templates/datarequests/show.html
+++ b/ckanext/data_qld/templates/datarequests/show.html
@@ -1,4 +1,7 @@
 {% ckan_extends %}
+{#
+Handle either old Pylons-style global variables, or newer template parameters.
+#}
 {% set datarequest = datarequest or c.datarequest %}
 
 {% block title %}Data request {{datarequest.get('title', '')}}{% endblock %}


### PR DESCRIPTION
The Data Requests plugin is dropping `c` to prepare for CKAN 2.11, we need to stop relying on it too.