### PR TITLE
[QOLDEV-1070] reduce usage of custom fixtures

### DIFF
--- a/ckanext/data_qld/tests/test_api.py
+++ b/ckanext/data_qld/tests/test_api.py
@@ -9,7 +9,6 @@ from ckan.plugins import toolkit as tk
 
 from ckanext.resource_visibility import constants as const
 
-from ckanext.data_qld.tests.conftest import _get_resource_schema
 from ckanext.data_qld.constants import FIELD_ALIGNMENT, FIELD_DEFAULT_SCHEMA
 
 
@@ -44,8 +43,8 @@ class TestApiPrivacyAssessment:
         assert const.FIELD_REQUEST_ASSESS not in resource
         assert const.FIELD_ASSESS_RESULT not in resource
 
-    def test_excluded_for_regular_user(self, dataset_factory, resource_factory,
-                                       user):
+    def test_excluded_for_regular_user(self, dataset_factory, resource_factory):
+        user = factories.User()
         dataset = dataset_factory()
         resource_factory(package_id=dataset["id"],
                          request_privacy_assessment=const.YES)
@@ -56,7 +55,8 @@ class TestApiPrivacyAssessment:
         assert const.FIELD_REQUEST_ASSESS not in resource
         assert const.FIELD_ASSESS_RESULT not in resource
 
-    def test_excluded_for_member(self, dataset_factory, resource_factory, user):
+    def test_excluded_for_member(self, dataset_factory, resource_factory):
+        user = factories.User()
         org = factories.Organization(users=[{
             "name": user["id"],
             "capacity": "member"
@@ -74,11 +74,11 @@ class TestApiPrivacyAssessment:
         assert const.FIELD_ASSESS_RESULT not in resource
 
     def test_excluded_for_editor_and_admin_of_another_org(
-            self, dataset_factory, user_factory, resource_factory):
+            self, dataset_factory, resource_factory):
         """An editor or administrator of an organization must have a special
         permission only within that organization and not in others."""
-        user1 = user_factory()
-        user2 = user_factory()
+        user1 = factories.User()
+        user2 = factories.User()
         factories.Organization(users=[{
             "name": user1["id"],
             "capacity": "editor"
@@ -98,10 +98,9 @@ class TestApiPrivacyAssessment:
             assert const.FIELD_REQUEST_ASSESS not in resource
             assert const.FIELD_ASSESS_RESULT not in resource
 
-    def test_present_for_editor_and_admin(self, dataset_factory, user_factory,
-                                          resource_factory):
-        user1 = user_factory()
-        user2 = user_factory()
+    def test_present_for_editor_and_admin(self, dataset_factory, resource_factory):
+        user1 = factories.User()
+        user2 = factories.User()
         org = factories.Organization(users=[{
             "name": user1["id"],
             "capacity": "editor"
@@ -121,8 +120,8 @@ class TestApiPrivacyAssessment:
             assert const.FIELD_REQUEST_ASSESS in resource
             assert const.FIELD_ASSESS_RESULT in resource
 
-    def test_present_for_sysadmin(self, dataset_factory, resource_factory,
-                                  sysadmin):
+    def test_present_for_sysadmin(self, dataset_factory, resource_factory):
+        sysadmin = factories.Sysadmin()
         dataset = dataset_factory()
         resource_factory(package_id=dataset["id"],
                          request_privacy_assessment=const.YES)
@@ -181,7 +180,8 @@ class TestResourceVisibility:
         assert pkg_dict["resources"]
         assert pkg_dict["num_resources"] == 1
 
-    def test_excluded_for_regular_user(self, dataset_factory, user):
+    def test_excluded_for_regular_user(self, dataset_factory):
+        user = factories.User()
         dataset = dataset_factory()
 
         pkg_dict = _get_pkg_dict(dataset['id'], user)
@@ -190,7 +190,8 @@ class TestResourceVisibility:
         assert pkg_dict["num_resources"] == 0
 
     def test_resource_page_not_accessible_for_regular_user_if_hidden(
-            self, dataset_factory, resource_factory, user):
+            self, dataset_factory, resource_factory):
+        user = factories.User()
         dataset = dataset_factory()
         resource = resource_factory(package_id=dataset["id"],
                                     resource_visible="FALSE")
@@ -201,11 +202,9 @@ class TestResourceVisibility:
                 data_dict={"id": resource['id']}
             )
 
-    def test_visible_for_editor_or_admin(self, dataset_factory,
-                                         resource_factory,
-                                         user_factory):
-        user1 = user_factory()
-        user2 = user_factory()
+    def test_visible_for_editor_or_admin(self, dataset_factory, resource_factory):
+        user1 = factories.User()
+        user2 = factories.User()
         org = factories.Organization(users=[{
             "name": user1["id"],
             "capacity": "editor"
@@ -223,8 +222,8 @@ class TestResourceVisibility:
             assert len(pkg_dict["resources"]) == 1
             assert pkg_dict["num_resources"] == 1
 
-    def test_visible_for_sysadmin(self, dataset_factory, resource_factory,
-                                  sysadmin):
+    def test_visible_for_sysadmin(self, dataset_factory, resource_factory):
+        sysadmin = factories.Sysadmin()
         dataset = dataset_factory()
         resource_factory(package_id=dataset["id"], resource_visible="FALSE")
         resource_factory(package_id=dataset["id"], resource_visible="FALSE")
@@ -235,8 +234,8 @@ class TestResourceVisibility:
         assert pkg_dict["num_resources"] == 2
 
     def test_regular_user_different_conditions(self, dataset_factory,
-                                               resource_factory, user):
-
+                                               resource_factory):
+        user = factories.User()
         # not resource_visible -> HIDE
         dataset = dataset_factory()
         resource_factory(package_id=dataset["id"], resource_visible="FALSE")
@@ -309,7 +308,8 @@ class TestResourceVisibility:
 class TestSchemaAlignment:
 
     def test_update_and_patch_default_schema(self, dataset_factory,
-                                             resource_factory, user):
+                                             resource_factory):
+        user = factories.User()
         org = factories.Organization(users=[{
             "name": user["id"],
             "capacity": "editor"
@@ -341,7 +341,8 @@ class TestSchemaAlignment:
         assert 'default_data_schema' not in pkg_dict
 
     def test_create_resource_with_custom_schema(self, dataset_factory,
-                                                resource_factory, user):
+                                                resource_factory):
+        user = factories.User()
         org = factories.Organization(users=[{
             "name": user["id"],
             "capacity": "editor"
@@ -366,7 +367,8 @@ class TestSchemaAlignment:
         assert resource['schema'] == schema
 
     def test_align_default_schema_visible_via_api(self, dataset_factory,
-                                                  resource_factory, user):
+                                                  resource_factory):
+        user = factories.User()
         dataset = dataset_factory()
         resource_factory(package_id=dataset["id"])
 
@@ -380,29 +382,30 @@ class TestSchemaAlignment:
 class TestDefaultSchemaAlignment:
 
     def test_update_default_schema_triggers_alignment_check(
-            self, dataset_factory, resource_factory, sysadmin):
+            self, dataset_factory, resource_factory, resource_schema):
         """Update of a default_schema must trigger check of schemas alignment"""
+        user = factories.User()
         dataset = dataset_factory()
-        resource = resource_factory(package_id=dataset["id"])
+        resource = resource_factory(package_id=dataset["id"], schema=resource_schema)
 
         assert not resource[FIELD_ALIGNMENT]
 
         call_action("package_patch",
-                    {"user": sysadmin['name']},
+                    {"user": user['name']},
                     id=dataset["id"],
-                    default_data_schema=_get_resource_schema())
+                    default_data_schema=resource_schema)
 
         resource = call_action("resource_show", id=resource["id"])
         assert resource[FIELD_ALIGNMENT]
 
-    def test_set_empty_default_schema(self, dataset_factory, resource_factory, sysadmin):
-        schema = _get_resource_schema()
-        dataset = dataset_factory(**{FIELD_DEFAULT_SCHEMA: schema})
-        resource = resource_factory(package_id=dataset["id"])
+    def test_set_empty_default_schema(self, dataset_factory, resource_factory, resource_schema):
+        user = factories.User()
+        dataset = dataset_factory(**{FIELD_DEFAULT_SCHEMA: resource_schema})
+        resource = resource_factory(package_id=dataset["id"], schema=resource_schema)
 
         assert resource[FIELD_ALIGNMENT]
 
-        call_action("package_patch", {"user": sysadmin['name']},
+        call_action("package_patch", {"user": user['name']},
                     id=dataset["id"], default_data_schema="")
 
         resource = call_action("resource_show", id=resource["id"])

--- a/ckanext/data_qld/tests/test_metadata.py
+++ b/ckanext/data_qld/tests/test_metadata.py
@@ -56,8 +56,8 @@ class TestCreateData:
         assert dataset["default_data_schema"]
         assert not dataset['schema_upload']
 
-    def test_json_schema(self, dataset_factory):
-        dataset = dataset_factory()
+    def test_json_schema(self, dataset_factory, dataset_schema):
+        dataset = dataset_factory(default_data_schema=dataset_schema)
 
         assert dataset["default_data_schema"]
         assert not dataset['schema_upload']

--- a/ckanext/data_qld/tests/test_reporting.py
+++ b/ckanext/data_qld/tests/test_reporting.py
@@ -100,14 +100,17 @@ class TestAdminReportDeIdentifiedNoSchema:
                          "mock_storage", "do_not_validate")
 class TestAdminReportCSVExport:
 
-    def test_as_regular_user_is_unauthorised(self, app, user):
+    def test_as_regular_user_is_unauthorised(self, app):
+        user = factories.User()
         app.get('/', extra_environ={"REMOTE_USER": str(user["name"])})
         org_id = factories.Organization()["id"]
 
-        app.get(f"/dashboard/reporting?report_type=admin&organisation={org_id}", status=403)
+        tk.current_user = model.User.get(user['id'])
+        with pytest.raises(tk.NotAuthorized):
+            helpers.gather_admin_metrics(org_id, "admin")
 
-    def test_as_sysadmin(self, app, dataset_factory, resource_factory,
-                         sysadmin):
+    def test_as_sysadmin(self, app, dataset_factory, resource_factory):
+        sysadmin = factories.Sysadmin()
         app.get('/', extra_environ={"REMOTE_USER": str(sysadmin["name"])})
         org_id = factories.Organization()["id"]
 
@@ -135,8 +138,8 @@ class TestAdminReportCSVExport:
         u"ckanext.data_qld.reporting.de_identified_no_schema.count_from",
         u"2045-01-01")
     def test_set_de_identified_count_from_in_future(self, app, dataset_factory,
-                                                    resource_factory,
-                                                    sysadmin):
+                                                    resource_factory):
+        sysadmin = factories.Sysadmin()
         app.get('/', extra_environ={"REMOTE_USER": str(sysadmin["name"])})
         org_id = factories.Organization()["id"]
 
@@ -162,8 +165,9 @@ class TestAdminReportCSVExport:
             ("2022-12-01T00:59", 0),
         ],
     )
-    def test_de_identified_parametrize(self, app, dataset_factory, sysadmin,
+    def test_de_identified_parametrize(self, app, dataset_factory,
                                        count_from, pkg_counter):
+        sysadmin = factories.Sysadmin()
         app.get('/', extra_environ={"REMOTE_USER": str(sysadmin["name"])})
         org_id = factories.Organization()["id"]
 

--- a/ckanext/data_qld/tests/test_resource_visibility.py
+++ b/ckanext/data_qld/tests/test_resource_visibility.py
@@ -20,14 +20,14 @@ class TestPrivacyAssessmentResultTracking:
         data = get_updated_privacy_assessment_result()
         assert not data
 
-    def test_updating_tracked(self, dataset_factory, resource_factory, sysadmin):
+    def test_updating_tracked(self, dataset_factory, resource_factory):
         dataset = dataset_factory(author_email=self.maintainer)
         resource = resource_factory(package_id=dataset["id"])
 
         data = get_updated_privacy_assessment_result()
         assert not data
 
-        call_action("resource_patch", {"user": sysadmin['name']},
+        call_action("resource_patch",
                     id=resource["id"],
                     privacy_assessment_result=self.assess_result)
 
@@ -49,11 +49,11 @@ class TestPrivacyAssessmentResultTracking:
                                         _external=True)
         assert tracked_data["url"] == resource_external_url
 
-    def test_clean_updated_stack(self, dataset_factory, resource_factory, sysadmin):
+    def test_clean_updated_stack(self, dataset_factory, resource_factory):
         dataset = dataset_factory(author_email=self.maintainer)
         resource = resource_factory(package_id=dataset["id"])
 
-        call_action("resource_patch", {"user": sysadmin['name']},
+        call_action("resource_patch",
                     id=resource["id"],
                     privacy_assessment_result=self.assess_result)
 

--- a/ckanext/data_qld/tests/test_validation.py
+++ b/ckanext/data_qld/tests/test_validation.py
@@ -1,6 +1,8 @@
 import pytest
 import mock
 
+from ckan.tests import factories
+
 import ckanext.validation.settings as validation_settings
 
 
@@ -9,11 +11,11 @@ import ckanext.validation.settings as validation_settings
 class TestValidationDefineCreateMode:
 
     def test_get_create_mode_if_has_schema_and_de_identified(
-            self, dataset_factory, resource_factory):
+            self, dataset_factory, resource_factory, resource_schema):
         """Validation must be in sync mode if we have a schema and dataset
         is de_identified"""
         dataset = dataset_factory(de_identified_data="YES")
-        resource = resource_factory(package_id=dataset["id"])
+        resource = resource_factory(package_id=dataset["id"], schema=resource_schema)
 
         mode = validation_settings.get_create_mode({}, resource)
         assert mode == validation_settings.SYNC_MODE
@@ -23,31 +25,31 @@ class TestValidationDefineCreateMode:
         """Validation must be in async mode if we don't have a schema and dataset
         is de_identified"""
         dataset = dataset_factory(de_identified_data="YES")
-        resource = resource_factory(package_id=dataset["id"], schema=None)
+        resource = resource_factory(package_id=dataset["id"])
 
         mode = validation_settings.get_create_mode({}, resource)
         assert mode == validation_settings.ASYNC_MODE
 
     def test_get_create_mode_if_has_schema_and_not_de_identified(
-            self, dataset_factory, resource_factory):
+            self, dataset_factory, resource_factory, resource_schema):
         """Validation must be in async mode if we have a schema and dataset
         is de_identified"""
         dataset = dataset_factory()
-        resource = resource_factory(package_id=dataset["id"])
+        resource = resource_factory(package_id=dataset["id"], schema=resource_schema)
 
         mode = validation_settings.get_create_mode({}, resource)
         assert mode == validation_settings.ASYNC_MODE
 
     @mock.patch("ckanext.data_qld.utils.is_api_call", lambda: False)
     def test_get_create_mode_if_no_schema_and_de_identified_but_aligned(
-            self, dataset_factory, resource_factory, sysadmin):
+            self, dataset_factory, resource_factory):
         """Validation must be in sync mode if we don't have a schema and dataset
         is de_identified, but resource schema is aligned with default schema"""
+        sysadmin = factories.Sysadmin()
         dataset = dataset_factory(de_identified_data="YES")
         resource = resource_factory(package_id=dataset["id"],
-                                    schema=None,
                                     align_default_schema=1,
-                                    context={"ignore_auth": False, "user": sysadmin["name"]})
+                                    context={"user": sysadmin["name"]})
 
         mode = validation_settings.get_create_mode({}, resource)
         assert mode == validation_settings.SYNC_MODE
@@ -58,11 +60,11 @@ class TestValidationDefineCreateMode:
 class TestValidationDefineUpdateMode:
 
     def test_get_update_mode_if_has_schema_and_de_identified(
-            self, dataset_factory, resource_factory):
+            self, dataset_factory, resource_factory, resource_schema):
         """Validation must be in sync mode if we have a schema and dataset
         is de_identified"""
         dataset = dataset_factory(de_identified_data="YES")
-        resource = resource_factory(package_id=dataset["id"])
+        resource = resource_factory(package_id=dataset["id"], schema=resource_schema)
 
         mode = validation_settings.get_update_mode({}, resource)
         assert mode == validation_settings.SYNC_MODE
@@ -72,31 +74,31 @@ class TestValidationDefineUpdateMode:
         """Validation must be in async mode if we don't have a schema and dataset
         is de_identified"""
         dataset = dataset_factory(de_identified_data="YES")
-        resource = resource_factory(package_id=dataset["id"], schema=None)
+        resource = resource_factory(package_id=dataset["id"])
 
         mode = validation_settings.get_update_mode({}, resource)
         assert mode == validation_settings.ASYNC_MODE
 
     def test_get_update_mode_if_has_schema_and_not_de_identified(
-            self, dataset_factory, resource_factory):
+            self, dataset_factory, resource_factory, resource_schema):
         """Validation must be in async mode if we have a schema and dataset
         is de_identified"""
         dataset = dataset_factory()
-        resource = resource_factory(package_id=dataset["id"])
+        resource = resource_factory(package_id=dataset["id"], schema=resource_schema)
 
         mode = validation_settings.get_update_mode({}, resource)
         assert mode == validation_settings.ASYNC_MODE
 
     @mock.patch("ckanext.data_qld.utils.is_api_call", lambda: False)
     def test_get_update_mode_if_no_schema_and_de_identified_but_aligned(
-            self, dataset_factory, resource_factory, sysadmin):
+            self, dataset_factory, resource_factory):
         """Validation must be in sync mode if we don't have a schema and dataset
         is de_identified, but resource schema is aligned with default schema"""
+        sysadmin = factories.Sysadmin()
         dataset = dataset_factory(de_identified_data="YES")
         resource = resource_factory(package_id=dataset["id"],
-                                    schema=None,
                                     align_default_schema=1,
-                                    context={"ignore_auth": False, "user": sysadmin["name"]})
+                                    context={"user": sysadmin["name"]})
 
         mode = validation_settings.get_update_mode({}, resource)
         assert mode == validation_settings.SYNC_MODE


### PR DESCRIPTION
- Drop 'user' and 'sysadmin' fixtures, just use standard CKAN test factories
- Drop unnecessary fields from dataset and resource fixtures, just keep essential defaults
- Inject schemas as fixtures where specifically needed instead of including in every test
- Cut unnecessary uploaded file in fixtures