### PR TITLE
[QOLDEV-1070] drop ckanext-harvest requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ckantoolkit>=0.0.4
 pyrsistent<0.17.0
 beautifulsoup4==4.9.1
-ckanext-harvest


### PR DESCRIPTION
- This requirement creates problems if plugins are installed in reverse order. TODO Define plugin installation order in cookbook to ensure inter-plugin dependencies are handled.