### PR TITLE
[QOLSVC-9308] apply our custom display name to data request status

### DIFF
--- a/ckanext/data_qld/templates/datarequests/index.html
+++ b/ckanext/data_qld/templates/datarequests/index.html
@@ -30,8 +30,5 @@
       {% endblock %}
     </div>
   </section>
-  {% for facet in facet_titles %}
-    {% set title = 'Status' if facet == 'state' else facet_titles[facet] %}
-    {{ h.snippet('snippets/facet_list.html', title=title, name=facet, search_facets=search_facets) }}
-  {% endfor %}
+  {{ super () }}
 {% endblock %}

--- a/ckanext/data_qld/templates/datarequests/index.html
+++ b/ckanext/data_qld/templates/datarequests/index.html
@@ -31,6 +31,7 @@
     </div>
   </section>
   {% for facet in facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets) }}
+    {% set title = 'Status' if facet == 'state' else facet_titles[facet] %}
+    {{ h.snippet('snippets/facet_list.html', title=title, name=facet, search_facets=search_facets) }}
   {% endfor %}
 {% endblock %}

--- a/test/features/datarequest.feature
+++ b/test/features/datarequest.feature
@@ -8,7 +8,7 @@ Feature: Data Request
         Given "Unauthenticated" as the persona
         When I go to the data requests page
         Then the browser's URL should contain "/datarequest"
-        And I should see an element with xpath "//nav[@aria-label = 'Status']"
+        And I should see an element with xpath "//nav[@aria-label = 'State']"
         And I should see an element with xpath "//span[contains(@class, 'item-label') and string() = 'Open']"
         And I should not see an element with xpath "//a[contains(translate(string(), 'DR', 'dr'), 'Add data request')]"
 
@@ -19,7 +19,7 @@ Feature: Data Request
         And I click the link with text that contains "Test Organisation"
         And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
         Then the browser's URL should contain "/organization/datarequest"
-        And I should see an element with xpath "//nav[@aria-label = 'Status']"
+        And I should see an element with xpath "//nav[@aria-label = 'State']"
         And I should see an element with xpath "//span[contains(@class, 'item-label') and string() = 'Open']"
         And I should see an element with xpath "//input[contains(@aria-label, 'Search Data Requests')]"
         And I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(@href, '/organization')]"
@@ -32,7 +32,7 @@ Feature: Data Request
         And I go to the "ckan_user" profile page
         And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
         Then the browser's URL should contain "/user/datarequest"
-        And I should see an element with xpath "//nav[@aria-label = 'Status']"
+        And I should see an element with xpath "//nav[@aria-label = 'State']"
         And I should see an element with xpath "//span[contains(@class, 'item-label') and string() = 'Open']"
         And I should see an element with xpath "//input[contains(@aria-label, 'Search Data Requests')]"
         And I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(@href, '/user') and contains(string(), 'Users')]"

--- a/test/features/datarequest.feature
+++ b/test/features/datarequest.feature
@@ -8,6 +8,7 @@ Feature: Data Request
         Given "Unauthenticated" as the persona
         When I go to the data requests page
         Then the browser's URL should contain "/datarequest"
+        And I should see an element with xpath "//nav[@aria-label = 'Status']"
         And I should see an element with xpath "//span[contains(@class, 'item-label') and string() = 'Open']"
         And I should not see an element with xpath "//a[contains(translate(string(), 'DR', 'dr'), 'Add data request')]"
 
@@ -18,6 +19,7 @@ Feature: Data Request
         And I click the link with text that contains "Test Organisation"
         And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
         Then the browser's URL should contain "/organization/datarequest"
+        And I should see an element with xpath "//nav[@aria-label = 'Status']"
         And I should see an element with xpath "//span[contains(@class, 'item-label') and string() = 'Open']"
         And I should see an element with xpath "//input[contains(@aria-label, 'Search Data Requests')]"
         And I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(@href, '/organization')]"
@@ -30,6 +32,7 @@ Feature: Data Request
         And I go to the "ckan_user" profile page
         And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
         Then the browser's URL should contain "/user/datarequest"
+        And I should see an element with xpath "//nav[@aria-label = 'Status']"
         And I should see an element with xpath "//span[contains(@class, 'item-label') and string() = 'Open']"
         And I should see an element with xpath "//input[contains(@aria-label, 'Search Data Requests')]"
         And I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(@href, '/user') and contains(string(), 'Users')]"


### PR DESCRIPTION
This was previously handled by overriding the template block.