### PR TITLE
QOLSVC-10984 ga4 touch ups

### DIFF
--- a/ckanext/data_qld/fanstatic/ga4_dataLayer_login.js
+++ b/ckanext/data_qld/fanstatic/ga4_dataLayer_login.js
@@ -1,0 +1,6 @@
+/* notify GA4 that client has logged in */
+window.dataLayer = window.dataLayer || [];
+dataLayer.push({
+  'event': 'login'
+});
+

--- a/ckanext/data_qld/fanstatic/ga4_dataLayer_logout.js
+++ b/ckanext/data_qld/fanstatic/ga4_dataLayer_logout.js
@@ -2,3 +2,6 @@
 dataLayer.push({
 'user_id': null
 });
+dataLayer.push({
+  'event': 'logged_out'
+});

--- a/ckanext/data_qld/fanstatic/webassets.yml
+++ b/ckanext/data_qld/fanstatic/webassets.yml
@@ -60,3 +60,12 @@ ga4_dataLayer_logout-js:
   extra:
     preload:
       - base/main
+
+ga4_dataLayer_login-js:
+  contents:
+    - ga4_dataLayer_login.js
+  filters: rjsmin
+  output: data_qld_theme/%(version)s_ga4_dataLayer_login.js
+  extra:
+    preload:
+      - base/main

--- a/ckanext/data_qld/templates/user/dashboard_datasets.html
+++ b/ckanext/data_qld/templates/user/dashboard_datasets.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block head_extras %}
+{{ super() }}
+{# normal visits to this page is post login #}
+{% asset 'data_qld_theme/ga4_dataLayer_login-js' %}
+{% endblock %}


### PR DESCRIPTION
client_id pseudo randomness per day for better session tracking of long running api jobs, also flag if logged in on api call.

Trigger events for login (dashboard dataset view which is the default drop location post login).
Trigger event 'logged_out' for logout page finish
