### PR TITLE
QOLDEV-979 update render to be able to run outside of flask as a task/job instead of inside the website runder engine

### DIFF
--- a/ckanext/data_qld/resource_freshness/helpers/helpers.py
+++ b/ckanext/data_qld/resource_freshness/helpers/helpers.py
@@ -4,7 +4,7 @@ import datetime as dt
 import json
 import logging
 
-from ckantoolkit import config, enqueue_job, g, get_action, get_validator, h, render
+from ckantoolkit import config, enqueue_job, g, get_action, get_validator, h, render_snippet
 from ckan.lib import mailer
 from ckan.model.resource import Resource
 
@@ -148,14 +148,14 @@ def send_email_dataset_notification(datasets_by_contacts, action_type):
                     contact_dataset.get('next_update_due'), '%Y-%m-%d')
 
                 datasets.append({
-                    'url': h.url_for('dataset_read', id=contact_dataset.get('name'), _external=True),
+                    'url': h.url_for('dataset.read', id=contact_dataset.get('name'), _external=True),
                     'next_due_date': date.strftime('%d/%m/%Y')
                 })
 
             extra_vars = {'datasets': datasets}
-            subject = render(
+            subject = render_snippet(
                 'emails/subjects/{0}.txt'.format(action_type), extra_vars)
-            body = render(
+            body = render_snippet(
                 'emails/bodies/{0}.txt'.format(action_type), extra_vars)
 
             site_title = 'Data | Queensland Government'


### PR DESCRIPTION


```
 [ckan.lib.helpers] Route name "dataset_read" is deprecated and will be removed. Please update calls to use "dataset.read" instead
```

```
Traceback (most recent call last):
  File "/mnt/local_data/ckan_venv/src/ckanext-data-qld/ckanext/data_qld/resource_freshness/helpers/helpers.py", line 156, in send_email_dataset_notification
    subject = render(
  File "/mnt/local_data/ckan_venv/src/ckan/ckan/lib/base.py", line 103, in render
    _allow_caching()
  File "/mnt/local_data/ckan_venv/src/ckan/ckan/lib/base.py", line 115, in _allow_caching
    elif ('user' in g and g.user) or _is_valid_session_cookie_data():
  File "/mnt/local_data/ckan_venv/lib64/python3.9/site-packages/werkzeug/local.py", line 318, in __get__
    obj = instance._get_current_object()
  File "/mnt/local_data/ckan_venv/lib64/python3.9/site-packages/werkzeug/local.py", line 519, in _get_current_object
    raise RuntimeError(unbound_message) from None
RuntimeError: Working outside of application context.
```