### PR TITLE
QOLDEV-2052 fix text decoration of link icons

### DIFF
--- a/ckanext/data_qld/fanstatic/data_qld.css
+++ b/ckanext/data_qld/fanstatic/data_qld.css
@@ -487,7 +487,7 @@ a.qld-header-link, a.nav-link, .qld-header-link a, .nav-link a {
 .navbar-collapse {
     margin-left: 0px;
 }
-a .fa::before {
+a .fa::before, a .fa-solid::before, a .fa-stack::before, a .fa-brands::before {
     /* Allow Font Awesome icons to have no underline on hover */
     display: inline-block;
 }

--- a/ckanext/data_qld/fanstatic/data_qld.css
+++ b/ckanext/data_qld/fanstatic/data_qld.css
@@ -487,6 +487,10 @@ a.qld-header-link, a.nav-link, .qld-header-link a, .nav-link a {
 .navbar-collapse {
     margin-left: 0px;
 }
+a .fa::before {
+    /* Allow Font Awesome icons to have no underline on hover */
+    display: inline-block;
+}
 
 li.nav-item a span.badge {
   float: right;

--- a/ckanext/data_qld/fanstatic/data_qld.css
+++ b/ckanext/data_qld/fanstatic/data_qld.css
@@ -491,6 +491,11 @@ a .fa::before, a .fa-solid::before, a .fa-stack::before, a .fa-brands::before {
     /* Allow Font Awesome icons to have no underline on hover */
     display: inline-block;
 }
+.pagination .page-item .page-link {
+    /* Handle page numbers above 2 digits */
+    width: unset;
+    min-width: 2rem;
+}
 
 li.nav-item a span.badge {
   float: right;

--- a/test/features/xloader.feature
+++ b/test/features/xloader.feature
@@ -5,7 +5,7 @@ Feature: XLoader
     Scenario: As a publisher, when I visit a resource I control with a datastore entry, I can access the XLoader interface
         Given "TestOrgEditor" as the persona
         When I log in
-        And I create a dataset and resource with key-value parameters "notes=Testing XLoader" and "name=test-csv-resource::url=https://people.sc.fsu.edu/~jburkardt/data/csv/addresses.csv::format=CSV"
+        And I create a dataset and resource with key-value parameters "notes=Testing XLoader" and "name=test-csv-resource::url=https://raw.githubusercontent.com/qld-gov-au/ckanext-data-qld/refs/heads/develop/test/fixtures/csv_resource.csv::format=CSV"
         # Wait for XLoader to run
         And I press "test-csv-resource"
         And I reload page every 3 seconds until I see an element with xpath "//*[contains(string(), 'DataStore')]" but not more than 6 times


### PR DESCRIPTION
Adjust display of Font Awesome icons inside links, so that they participate properly in text decoration (ie they aren't underlined on hover).