### PR TITLE
[QOLDEV-2052] add QGDS bootstrap script

### DIFF
--- a/ckanext/data_qld/templates/base.html
+++ b/ckanext/data_qld/templates/base.html
@@ -11,15 +11,16 @@
 {% endblock %}
 
 {% block custom_styles %}
-{{ super() }}
+  {{ super() }}
   <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" />
   <link href="{{ h.set_external_resources() }}/__data/assets/git_bridge/0019/100846/open-data/dist/qld.css?h=eeb329b" rel="stylesheet" />
   <link href="https://static.qgov.net.au/qgds-bootstrap5/v2/v2.2.1/assets/css/qld.bootstrap.css" rel="stylesheet" />
   {% include 'snippets/data_qld_asset.html' %}
 {% endblock %}
 
-{% block head_extras %}
-{{ super() }}
+{% block scripts %}
+    {{ super() }}
+    <script type="text/javascript" src="https://static.qgov.net.au/qgds-bootstrap5/v2/v2.2.1/assets/js/qld.bootstrap.min.js" defer></script>
 
 {# GA4 user
 Add only if user is logged in #}

--- a/ckanext/data_qld/templates/header.html
+++ b/ckanext/data_qld/templates/header.html
@@ -126,7 +126,7 @@
                 <div class="col-lg-4">
                   {% block header_site_search %}
                     <div id="qld-header-search" class="qld-header-site-search is-closed">
-                      <form class="site-search" role="search" action="{% url_for dataset_type ~ '.search' %}" method="get">
+                      <form role="search" action="{% url_for dataset_type ~ '.search' %}" method="get">
                         <!--
                             QGDS Component: Search input
                         -->


### PR DESCRIPTION
- This fixes the mobile search button
- Drop 'site-search' class from our search form so that the bootstrap script won't inject Funnelback-specific parameters