### PR TITLE
QOLDEV-2052 convert breadcrumbs to QGDS

### DIFF
--- a/ckanext/data_qld/fanstatic/data_qld.css
+++ b/ckanext/data_qld/fanstatic/data_qld.css
@@ -503,6 +503,136 @@ a.badge {
     color: var(--qld-badge-color);
     text-underline-offset: unset;
 }
+/* Apply breadcrumb styling to any 'li' inside the breadcrumb list,
+ * instead of requiring each one to have a 'breadcrumb-item' class,
+ * since many instances will be in templates controlled by plugins.
+ */
+.main {
+    /* Breadcrumbs above the 'main' div will handle padding */
+    padding-top: unset;
+}
+.breadcrumb li + .breadcrumb li {
+    padding-left: var(--qld-breadcrumb-item-padding-x)
+}
+.breadcrumb li + .breadcrumb li:before {
+    float: left;
+    padding-right: var(--qld-breadcrumb-item-padding-x);
+    color: var(--qld-breadcrumb-divider-color);
+    content: var(--qld-breadcrumb-divider, "/")
+}
+.breadcrumb li.active {
+    color: var(--qld-breadcrumb-item-active-color)
+}
+.breadcrumb li {
+    font-size: .875rem;
+    line-height: 2rem;
+    display: none;
+    white-space: nowrap
+}
+.breadcrumb li:not(:first-child) a {
+    margin-left: 5px
+}
+.breadcrumb li:nth-last-child(2) {
+    text-overflow: ellipsis;
+    overflow-x: hidden;
+    white-space: nowrap
+}
+.breadcrumb li:nth-last-child(2):focus-within {
+    overflow: initial
+}
+.breadcrumb li:first-child {
+    flex-shrink: 0
+}
+.breadcrumb li a {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap
+}
+.breadcrumb li a:focus {
+    overflow: initial
+}
+.breadcrumb li:before {
+    display: none
+}
+.breadcrumb li:after {
+    content: "";
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    -webkit-mask-image: var(--qld-breadcrumb-divider);
+    mask-image: var(--qld-breadcrumb-divider);
+    -webkit-mask-size: 1rem 1rem;
+    mask-size: 1rem 1rem;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center center;
+    mask-position: center center;
+    background-color: var(--qld-breadcrumb-divider-color);
+    position: relative;
+    top: 4px
+}
+.breadcrumb li:last-child:after {
+    display: none
+}
+.breadcrumb li a, .breadcrumb li a:visited, .breadcrumb li a:hover {
+    color: var(--qld-breadcrumb-link-color);
+    text-decoration-color: var(--qld-breadcrumb-link-text-decoration-color)
+}
+.breadcrumb li a {
+    outline: 3px solid transparent;
+    outline-offset: -3px
+}
+.breadcrumb li a:focus {
+    outline-width: 3px;
+    outline-style: solid;
+    outline-color: var(--qld-focus-color, #002e85);
+    outline-offset: 3px
+}
+@media (max-width: 991.98px) {
+    .breadcrumb li {
+        max-width: unset
+    }
+
+    .breadcrumb li:nth-last-child(2) {
+        display: flex;
+        flex-direction: row-reverse;
+        min-width: 0
+    }
+
+    .breadcrumb li:nth-last-child(2):after {
+        -webkit-transform: rotate(180deg);
+        transform: rotate(180deg);
+        -webkit-transform-origin: center;
+        transform-origin: center;
+        margin-left: -.25rem;
+        top: 7px;
+        min-width: 1.5rem
+    }
+}
+@media (min-width: 992px) {
+    .breadcrumb li {
+        display: inline;
+        font-size: 1rem
+    }
+
+    .breadcrumb li.active {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: inline-block;
+        flex-shrink: 999999;
+        margin-left: 4px
+    }
+}
+@media print {
+    .breadcrumb a:after, .breadcrumb li a:after {
+        content: " >"
+    }
+
+    .breadcrumb li.breadcrumb-toggle {
+        display: none !important
+    }
+}
 
 li.nav-item a span.badge {
   float: right;

--- a/ckanext/data_qld/templates/header.html
+++ b/ckanext/data_qld/templates/header.html
@@ -59,7 +59,7 @@
                         {% block header_account_log_out_link %}
                           <form action="{{ h.url_for('user.logout') }}" method="post">
                             {{ h.csrf_input() }}
-                            <button class="qld-header-link ms-16 p-0 bg-transparent border-0" type="submit" title="{{ _('Log out') }}">
+                            <button class="qld-header-link p-0 bg-transparent border-0" type="submit" title="{{ _('Log out') }}">
                               <i class="fa fa-sign-out qld-icon-sm qld-header-link-icon" aria-hidden="true"></i>{{ _('Log out') }}
                             </button>
                           </form>

--- a/ckanext/data_qld/templates/page.html
+++ b/ckanext/data_qld/templates/page.html
@@ -9,45 +9,43 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     {{ super() }}
 {% endblock %}
 
-{% block maintag %}
-    <div role="main" class="main {{ h.set_background_image_class() }}">
-{% endblock %}
-
-{% block secondary %}
-    <aside class="secondary col-sm-5 col-md-4 col-lg-4">
-        {#
-        The secondary_content block can be used to add content to the
-        sidebar of the page. This is the main block that is likely to be
-        used within a template.
-
-        Example:
-
-        {% block secondary_content %}
-            <h2>A sidebar item</h2>
-            <p>Some content for the item</p>
-        {% endblock %}
-        #}
-        {% block secondary_content %}
-          {{ super() }}
-        {% endblock %}
-    </aside>
-{% endblock %}
-
-{% block primary %}
-    <div class="primary col-xs-12 col-sm-7 col-md-8 col-lg-8">
-        {#
-        The primary_content block can be used to add content to the page.
-        This is the main block that is likely to be used within a template.
-
-        Example:
-
-        {% block primary_content %}
-            <h1>My page content</h1>
-            <p>Some content for the page</p>
-        {% endblock %}
-        #}
-        {% block primary_content %}
-          {{ super() }}
-        {% endblock %}
+{%- block content %}
+  {% block toolbar %}
+    {# Drop the 'toolbar' class as that interferes with QGDS #}
+    <div role="navigation" aria-label="{{ _('Breadcrumb') }}">
+      {% block breadcrumb %}
+        {{ super() }}
+      {% endblock %}
     </div>
-{% endblock %}
+  {% endblock %}
+  {% block maintag %}<div role="main" class="main {{ h.set_background_image_class() }}">{% endblock %}
+    <div id="content" class="container">
+      {% block main_content %}
+        {% block flash %}
+          {{ super() }}
+        {% endblock %}
+
+        <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
+          {% block pre_primary %}
+          {% endblock %}
+
+          {% block secondary %}
+              <aside class="secondary col-sm-5 col-md-4 col-lg-4">
+                  {% block secondary_content %}
+                      {{ super() }}
+                  {% endblock %}
+              </aside>
+          {% endblock %}
+
+          {% block primary %}
+              <div class="primary col-xs-12 col-sm-7 col-md-8 col-lg-8">
+                  {% block primary_content %}
+                      {{ super() }}
+                  {% endblock %}
+              </div>
+          {% endblock %}
+        </div>
+      {% endblock %}
+    </div>
+  </div>
+{% endblock -%}

--- a/ckanext/data_qld/templates/page.html
+++ b/ckanext/data_qld/templates/page.html
@@ -9,43 +9,31 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     {{ super() }}
 {% endblock %}
 
-{%- block content %}
-  {% block toolbar %}
-    {# Drop the 'toolbar' class as that interferes with QGDS #}
-    <div role="navigation" aria-label="{{ _('Breadcrumb') }}">
-      {% block breadcrumb %}
-        {{ super() }}
-      {% endblock %}
-    </div>
-  {% endblock %}
-  {% block maintag %}<div role="main" class="main {{ h.set_background_image_class() }}">{% endblock %}
-    <div id="content" class="container">
-      {% block main_content %}
-        {% block flash %}
+{% block maintag %}
+    <div role="main" class="main {{ h.set_background_image_class() }}">
+{% endblock %}
+
+{% block toolbar %}
+  {# Drop the 'toolbar' class as that interferes with QGDS #}
+  <div role="navigation" aria-label="{{ _('Breadcrumb') }}">
+    {% block breadcrumb %}
+      {{ super() }}
+    {% endblock %}
+  </div>
+{% endblock %}
+
+{% block secondary %}
+    <aside class="secondary col-sm-5 col-md-4 col-lg-4">
+        {% block secondary_content %}
+            {{ super() }}
+        {% endblock %}
+    </aside>
+{% endblock %}
+
+{% block primary %}
+    <div class="primary col-xs-12 col-sm-7 col-md-8 col-lg-8">
+        {% block primary_content %}
           {{ super() }}
         {% endblock %}
-
-        <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
-          {% block pre_primary %}
-          {% endblock %}
-
-          {% block secondary %}
-              <aside class="secondary col-sm-5 col-md-4 col-lg-4">
-                  {% block secondary_content %}
-                      {{ super() }}
-                  {% endblock %}
-              </aside>
-          {% endblock %}
-
-          {% block primary %}
-              <div class="primary col-xs-12 col-sm-7 col-md-8 col-lg-8">
-                  {% block primary_content %}
-                      {{ super() }}
-                  {% endblock %}
-              </div>
-          {% endblock %}
-        </div>
-      {% endblock %}
     </div>
-  </div>
-{% endblock -%}
+{% endblock %}


### PR DESCRIPTION
- Add breadcrumb styles to all children of the `breadcrumb` list without requiring them to have the `breadcrumb-item` class
- Adjust page structure to put breadcrumbs above the `main` div.